### PR TITLE
Add ingestion lambda for bushfire data feeds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+boto3
+requests

--- a/src/ingest_lambda/handlers.py
+++ b/src/ingest_lambda/handlers.py
@@ -1,0 +1,117 @@
+import os
+import json
+from typing import List, Dict, Any
+
+import requests
+import boto3
+
+FIREHOSE_STREAM_NAME = os.environ.get("FIREHOSE_STREAM_NAME", "bushfire_raw")
+
+firehose = boto3.client("firehose", region_name=os.environ.get("AWS_REGION", "us-east-1"))
+
+NSW_RFS_URL = "https://www.rfs.nsw.gov.au/feeds/majorIncidents.json"
+NASA_FIRMS_URL = (
+    "https://firms.modaps.eosdis.nasa.gov/active_fire/c6/geojson/MODIS_C6_Australia_NewZealand_24h.geojson"
+)
+NSW_EPN_URL = "https://data.airquality.nsw.gov.au/api/Data/Hourly/Average"
+
+def fetch_json(url: str) -> Dict[str, Any]:
+    """Fetch JSON data from a URL."""
+    resp = requests.get(url, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+def normalize_nsw_rfs(data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Normalize NSW RFS major incident feed."""
+    features = data.get("features", [])
+    normalized = []
+    for feat in features:
+        prop = feat.get("properties", {})
+        geom = feat.get("geometry", {})
+        coords = geom.get("coordinates", [None, None])
+        normalized.append(
+            {
+                "source": "nsw_rfs",
+                "id": prop.get("id") or prop.get("objectid"),
+                "latitude": coords[1],
+                "longitude": coords[0],
+                "timestamp": prop.get("updated") or prop.get("pubdate"),
+                "raw": prop,
+            }
+        )
+    return normalized
+
+def normalize_nasa_firms(data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Normalize NASA FIRMS feed."""
+    features = data.get("features", [])
+    normalized = []
+    for feat in features:
+        prop = feat.get("properties", {})
+        geom = feat.get("geometry", {})
+        coords = geom.get("coordinates", [None, None])
+        acq_date = prop.get("acq_date")
+        acq_time = prop.get("acq_time")
+        ts = None
+        if acq_date and acq_time:
+            ts = f"{acq_date}T{acq_time}Z"
+        normalized.append(
+            {
+                "source": "nasa_firms",
+                "id": prop.get("id") or prop.get("fid"),
+                "latitude": coords[1],
+                "longitude": coords[0],
+                "timestamp": ts,
+                "raw": prop,
+            }
+        )
+    return normalized
+
+def normalize_nsw_epn(data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Normalize NSW Environmental Protection data feed."""
+    records = data.get("records", []) or data.get("data", [])
+    normalized = []
+    for rec in records:
+        normalized.append(
+            {
+                "source": "nsw_epn",
+                "id": rec.get("Site") or rec.get("station"),
+                "latitude": rec.get("Latitude") or rec.get("lat"),
+                "longitude": rec.get("Longitude") or rec.get("lon"),
+                "timestamp": rec.get("Date") or rec.get("timestamp"),
+                "raw": rec,
+            }
+        )
+    return normalized
+
+def send_to_firehose(records: List[Dict[str, Any]]) -> int:
+    """Send records to Kinesis Firehose."""
+    if not records:
+        return 0
+
+    def chunk(lst: List[Dict[str, Any]], size: int):
+        for i in range(0, len(lst), size):
+            yield lst[i : i + size]
+
+    sent = 0
+    for batch in chunk(records, 500):
+        response = firehose.put_record_batch(
+            DeliveryStreamName=FIREHOSE_STREAM_NAME,
+            Records=[{"Data": json.dumps(rec) + "\n"} for rec in batch],
+        )
+        failures = response.get("FailedPutCount", 0)
+        sent += len(batch) - failures
+    return sent
+
+def handler(event, context):
+    nsw_rfs_data = fetch_json(NSW_RFS_URL)
+    nasa_firms_data = fetch_json(NASA_FIRMS_URL)
+    nsw_epn_data = fetch_json(NSW_EPN_URL)
+
+    records = (
+        normalize_nsw_rfs(nsw_rfs_data)
+        + normalize_nasa_firms(nasa_firms_data)
+        + normalize_nsw_epn(nsw_epn_data)
+    )
+
+    send_to_firehose(records)
+    return {"records": len(records)}

--- a/template.yaml
+++ b/template.yaml
@@ -1,0 +1,57 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Bushfire ingestion lambda with scheduled trigger
+
+Resources:
+  IngestLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/AWSLambdaVPCAccessExecutionRole
+      Policies:
+        - PolicyName: FirehosePutPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - firehose:PutRecordBatch
+                Resource: arn:aws:firehose:*:*:deliverystream/bushfire_raw
+
+  IngestLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Runtime: python3.11
+      Handler: ingest_lambda.handlers.handler
+      Role: !GetAtt IngestLambdaRole.Arn
+      Code:
+        S3Bucket: PLACEHOLDER_BUCKET
+        S3Key: PLACEHOLDER_KEY
+      Timeout: 60
+      MemorySize: 256
+      Environment:
+        Variables:
+          FIREHOSE_STREAM_NAME: bushfire_raw
+
+  IngestEventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      ScheduleExpression: rate(30 seconds)
+      Targets:
+        - Arn: !GetAtt IngestLambda.Arn
+          Id: IngestLambdaTarget
+
+  PermissionForEventsToInvokeLambda:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref IngestLambda
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt IngestEventRule.Arn

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,80 @@
+import os, sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from ingest_lambda.handlers import (
+    normalize_nsw_rfs,
+    normalize_nasa_firms,
+    normalize_nsw_epn,
+)
+
+
+def test_normalize_nsw_rfs():
+    sample = {
+        "features": [
+            {
+                "properties": {"id": "1", "updated": "2024-04-22T10:00:00Z"},
+                "geometry": {"coordinates": [150.0, -33.0]},
+            }
+        ]
+    }
+    result = normalize_nsw_rfs(sample)
+    assert result == [
+        {
+            "source": "nsw_rfs",
+            "id": "1",
+            "latitude": -33.0,
+            "longitude": 150.0,
+            "timestamp": "2024-04-22T10:00:00Z",
+            "raw": {"id": "1", "updated": "2024-04-22T10:00:00Z"},
+        }
+    ]
+
+
+def test_normalize_nasa_firms():
+    sample = {
+        "features": [
+            {
+                "properties": {"fid": "abc", "acq_date": "2024-04-22", "acq_time": "0830"},
+                "geometry": {"coordinates": [151.0, -32.0]},
+            }
+        ]
+    }
+    result = normalize_nasa_firms(sample)
+    assert result == [
+        {
+            "source": "nasa_firms",
+            "id": "abc",
+            "latitude": -32.0,
+            "longitude": 151.0,
+            "timestamp": "2024-04-22T0830Z",
+            "raw": {"fid": "abc", "acq_date": "2024-04-22", "acq_time": "0830"},
+        }
+    ]
+
+
+def test_normalize_nsw_epn():
+    sample = {
+        "records": [
+            {
+                "Site": "Sydney",
+                "Latitude": -33.86,
+                "Longitude": 151.2,
+                "Date": "2024-04-22T00:00:00Z",
+            }
+        ]
+    }
+    result = normalize_nsw_epn(sample)
+    assert result == [
+        {
+            "source": "nsw_epn",
+            "id": "Sydney",
+            "latitude": -33.86,
+            "longitude": 151.2,
+            "timestamp": "2024-04-22T00:00:00Z",
+            "raw": {
+                "Site": "Sydney",
+                "Latitude": -33.86,
+                "Longitude": 151.2,
+                "Date": "2024-04-22T00:00:00Z",
+            },
+        }
+    ]


### PR DESCRIPTION
## Summary
- create ingestion lambda to fetch NSW RFS, NASA FIRMS and NSW EPN feeds and push to Firehose
- define IAM role and EventBridge rule for scheduled execution
- add requirements and unit tests for feed normalization

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e3ce934e08329b8f0a60004c781a1