### PR TITLE
Add ALB failure simulation and ECS chaos automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,9 @@ koalasafe-cloud/
 │   └── geojson_processor/         # Dockerised Fargate app
 ├── frontend/                      # Vite + React + Mapbox
 ├── scripts/
-│   └── failure_sim.sh             # Game‑day automation
+│   ├── failure_sim.sh             # Game-day automation
+│   ├── ecs_chaos_automation.yaml  # SSM document to stop random ECS task
+│   └── schedule_chaos.sh          # Publish and schedule automation
 ├── .github/workflows/             # GHA pipelines
 ├── docs/
 │   ├── architecture.drawio
@@ -298,12 +300,12 @@ Grafana dashboards JSON exported to `docs/grafana/*.json`.
 ## Disaster Recovery & Game‑Day Scenarios
 
 * **Fail‑over Mechanism**: Route 53 weighted records 80 % → Sydney, 20 % → Melbourne; health check on `/health` ALB path.
-* **Game‑day Script** (`scripts/failure_sim.sh`):
+* **Game-day Script** (`scripts/failure_sim.sh`):
 
-  1. Terminates primary ALB.
-  2. Monitors Route 53 `HealthCheckPercentage` until fail‑over occurs (< 60 s).
-  3. Restores ALB; flips traffic back.
-* **Chaos Plan**: Use SSM Automation to randomly stop ECS tasks during business hours once/week.
+    1. Disables deletion protection and deletes the primary ALB.
+    2. Polls Route 53 health check until fail-over occurs.
+    3. Recreates the ALB from a CloudFormation template and waits for it to become healthy.
+* **Chaos Plan**: `scripts/schedule_chaos.sh` publishes an SSM Automation document (`scripts/ecs_chaos_automation.yaml`) that randomly stops an ECS task and schedules it to run weekly.
 
 ---
 

--- a/scripts/ecs_chaos_automation.yaml
+++ b/scripts/ecs_chaos_automation.yaml
@@ -1,0 +1,32 @@
+---
+description: "Randomly stop an ECS task to simulate failure"
+schemaVersion: '0.3'
+parameters:
+  ClusterName:
+    type: String
+    description: ECS cluster name
+  ServiceName:
+    type: String
+    description: ECS service to target
+  AutomationAssumeRole:
+    type: String
+    description: IAM role that allows Systems Manager Automation to run this document
+    default: ""
+mainSteps:
+  - name: ChooseAndStopTask
+    action: 'aws:executeScript'
+    inputs:
+      Runtime: python3.8
+      Handler: run
+      Script: |
+        import boto3, random
+        ecs = boto3.client('ecs')
+        cluster = params['ClusterName']
+        service = params['ServiceName']
+        tasks = ecs.list_tasks(cluster=cluster, serviceName=service)['taskArns']
+        if not tasks:
+          raise Exception('No running tasks found')
+        task = random.choice(tasks)
+        ecs.stop_task(cluster=cluster, task=task, reason='Chaos experiment')
+        return {'stoppedTask': task}
+    onFailure: Abort

--- a/scripts/failure_sim.sh
+++ b/scripts/failure_sim.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<EOT
+Usage: $0 --alb-arn ARN --health-check-id ID --template-file FILE [--region REGION]
+
+Simulates failure of the primary ALB by deleting it and waits for Route 53 fail-over.
+After fail-over is detected, the ALB is restored using the provided CloudFormation template.
+
+Required parameters:
+  --alb-arn           ARN of the primary Application Load Balancer
+  --health-check-id   ID of the Route 53 health check monitoring the ALB
+  --template-file     CloudFormation template used to recreate the ALB
+Optional parameters:
+  --region            AWS region (default: us-east-1)
+EOT
+}
+
+ALB_ARN=""
+HEALTH_CHECK_ID=""
+TEMPLATE_FILE=""
+REGION="us-east-1"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --alb-arn) ALB_ARN="$2"; shift 2;;
+    --health-check-id) HEALTH_CHECK_ID="$2"; shift 2;;
+    --template-file) TEMPLATE_FILE="$2"; shift 2;;
+    --region) REGION="$2"; shift 2;;
+    -h|--help) usage; exit 0;;
+    *) echo "Unknown option: $1"; usage; exit 1;;
+  esac
+ done
+
+if [[ -z "$ALB_ARN" || -z "$HEALTH_CHECK_ID" || -z "$TEMPLATE_FILE" ]]; then
+  usage
+  exit 1
+fi
+
+echo "Disabling deletion protection for ALB..."
+aws elbv2 modify-load-balancer-attributes \
+  --load-balancer-arn "$ALB_ARN" \
+  --attributes Key=deletion_protection.enabled,Value=false \
+  --region "$REGION"
+
+echo "Deleting ALB $ALB_ARN..."
+aws elbv2 delete-load-balancer \
+  --load-balancer-arn "$ALB_ARN" \
+  --region "$REGION"
+
+echo "Waiting for Route 53 health check $HEALTH_CHECK_ID to report failure..."
+while true; do
+  STATUS=$(aws route53 get-health-check-status \
+    --health-check-id "$HEALTH_CHECK_ID" \
+    --query 'HealthCheckObservations[*].StatusReport.Status' \
+    --output text)
+  echo "Current health check statuses: $STATUS"
+  if [[ "$STATUS" == *"Failure"* ]]; then
+    echo "Fail-over detected."
+    break
+  fi
+  sleep 30
+ done
+
+echo "Restoring ALB using template $TEMPLATE_FILE..."
+aws cloudformation deploy \
+  --stack-name primary-alb \
+  --template-file "$TEMPLATE_FILE" \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --region "$REGION"
+
+NEW_ALB_ARN=$(aws cloudformation describe-stacks \
+  --stack-name primary-alb \
+  --query 'Stacks[0].Outputs[?OutputKey==`LoadBalancerArn`].OutputValue' \
+  --output text \
+  --region "$REGION")
+
+echo "Waiting for ALB $NEW_ALB_ARN to become active..."
+aws elbv2 wait load-balancer-available \
+  --load-balancer-arns "$NEW_ALB_ARN" \
+  --region "$REGION"
+
+echo "ALB restored. Failover test complete."

--- a/scripts/schedule_chaos.sh
+++ b/scripts/schedule_chaos.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <cluster-name> <service-name>" >&2
+  echo "Environment variables: REGION, ACCOUNT_ID, AUTOMATION_ROLE_ARN" >&2
+}
+
+if [[ $# -lt 2 ]]; then
+  usage
+  exit 1
+fi
+
+CLUSTER="$1"
+SERVICE="$2"
+REGION="${REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:?ACCOUNT_ID env var required}"
+ROLE_ARN="${AUTOMATION_ROLE_ARN:?AUTOMATION_ROLE_ARN env var required}"
+DOC_NAME="ECSChaosExperiment"
+DOC_FILE="$(dirname "$0")/ecs_chaos_automation.yaml"
+
+printf 'Publishing automation document %s...\n' "$DOC_NAME"
+aws ssm delete-document --name "$DOC_NAME" --region "$REGION" >/dev/null 2>&1 || true
+aws ssm create-document \
+  --name "$DOC_NAME" \
+  --document-type Automation \
+  --content file://"$DOC_FILE" \
+  --region "$REGION" >/dev/null
+
+printf 'Scheduling weekly chaos experiment...\n'
+aws events put-rule \
+  --name "${DOC_NAME}Weekly" \
+  --schedule-expression 'cron(0 3 ? * MON-FRI *)' \
+  --region "$REGION" >/dev/null
+
+aws events put-targets \
+  --rule "${DOC_NAME}Weekly" \
+  --targets "Id"="1","Arn"="arn:aws:ssm:${REGION}:${ACCOUNT_ID}:automation-definition/${DOC_NAME}","RoleArn"="${ROLE_ARN}","Input"="{\"ClusterName\":\"${CLUSTER}\",\"ServiceName\":\"${SERVICE}\"}" \
+  --region "$REGION" >/dev/null
+
+printf 'Chaos schedule created.\n'


### PR DESCRIPTION
## Summary
- add failure_sim.sh to delete the primary ALB, watch Route 53 health checks, and restore via CloudFormation
- document restoration steps and chaos experiment setup in README
- add SSM Automation document and scheduler to randomly stop ECS tasks

## Testing
- `bash scripts/failure_sim.sh --help`
- `bash scripts/schedule_chaos.sh`
- `bash -n scripts/failure_sim.sh`
- `bash -n scripts/schedule_chaos.sh`
