### PR TITLE
Add Terraform modules for core infrastructure

### DIFF
--- a/terraform/compute-fargate/.terraform.lock.hcl
+++ b/terraform/compute-fargate/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/compute-fargate/main.tf
+++ b/terraform/compute-fargate/main.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_ecs_cluster" "this" {
+  name = "${var.name}-cluster"
+}
+
+resource "aws_lb" "app" {
+  name               = "${var.name}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  subnets            = var.subnet_ids
+  security_groups    = var.security_group_ids
+}

--- a/terraform/compute-fargate/outputs.tf
+++ b/terraform/compute-fargate/outputs.tf
@@ -1,0 +1,7 @@
+output "ecs_cluster_id" {
+  value = aws_ecs_cluster.this.id
+}
+
+output "alb_arn" {
+  value = aws_lb.app.arn
+}

--- a/terraform/compute-fargate/variables.tf
+++ b/terraform/compute-fargate/variables.tf
@@ -1,0 +1,19 @@
+variable "name" {
+  type        = string
+  description = "Name prefix for resources"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "Subnet IDs for the load balancer"
+}
+
+variable "security_group_ids" {
+  type        = list(string)
+  description = "Security groups for the load balancer"
+}

--- a/terraform/compute-fargate/versions.tf
+++ b/terraform/compute-fargate/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  backend "s3" {
+    bucket               = "koalasafe-terraform-state"
+    key                  = "terraform.tfstate"
+    region               = "ap-southeast-2"
+    dynamodb_table       = "koalasafe-terraform-locks"
+    encrypt              = true
+    workspace_key_prefix = "compute-fargate"
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/core-network/.terraform.lock.hcl
+++ b/terraform/core-network/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/core-network/main.tf
+++ b/terraform/core-network/main.tf
@@ -1,0 +1,31 @@
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = var.vpc_cidr
+  tags = {
+    Name = "${var.name}-vpc"
+  }
+}
+
+resource "aws_subnet" "public" {
+  count                   = length(var.public_subnet_cidrs)
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  availability_zone       = element(var.availability_zones, count.index)
+  map_public_ip_on_launch = true
+  tags = {
+    Name = "${var.name}-public-${count.index}"
+  }
+}
+
+resource "aws_subnet" "private" {
+  count             = length(var.private_subnet_cidrs)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_cidrs[count.index]
+  availability_zone = element(var.availability_zones, count.index)
+  tags = {
+    Name = "${var.name}-private-${count.index}"
+  }
+}

--- a/terraform/core-network/outputs.tf
+++ b/terraform/core-network/outputs.tf
@@ -1,0 +1,11 @@
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "public_subnet_ids" {
+  value = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  value = aws_subnet.private[*].id
+}

--- a/terraform/core-network/variables.tf
+++ b/terraform/core-network/variables.tf
@@ -1,0 +1,29 @@
+variable "name" {
+  type        = string
+  description = "Name prefix for resources"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region"
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "CIDR block for the VPC"
+}
+
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "CIDR blocks for public subnets"
+}
+
+variable "private_subnet_cidrs" {
+  type        = list(string)
+  description = "CIDR blocks for private subnets"
+}
+
+variable "availability_zones" {
+  type        = list(string)
+  description = "Availability zones for subnets"
+}

--- a/terraform/core-network/versions.tf
+++ b/terraform/core-network/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  backend "s3" {
+    bucket               = "koalasafe-terraform-state"
+    key                  = "terraform.tfstate"
+    region               = "ap-southeast-2"
+    dynamodb_table       = "koalasafe-terraform-locks"
+    encrypt              = true
+    workspace_key_prefix = "core-network"
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/data-storage/.terraform.lock.hcl
+++ b/terraform/data-storage/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/data-storage/main.tf
+++ b/terraform/data-storage/main.tf
@@ -1,0 +1,19 @@
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_s3_bucket" "data" {
+  bucket        = "${var.name}-data-${terraform.workspace}"
+  force_destroy = true
+}
+
+resource "aws_dynamodb_table" "metadata" {
+  name         = "${var.name}-metadata-${terraform.workspace}"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+}

--- a/terraform/data-storage/outputs.tf
+++ b/terraform/data-storage/outputs.tf
@@ -1,0 +1,7 @@
+output "bucket_name" {
+  value = aws_s3_bucket.data.bucket
+}
+
+output "dynamodb_table_name" {
+  value = aws_dynamodb_table.metadata.name
+}

--- a/terraform/data-storage/variables.tf
+++ b/terraform/data-storage/variables.tf
@@ -1,0 +1,9 @@
+variable "name" {
+  type        = string
+  description = "Name prefix for resources"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region"
+}

--- a/terraform/data-storage/versions.tf
+++ b/terraform/data-storage/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  backend "s3" {
+    bucket               = "koalasafe-terraform-state"
+    key                  = "terraform.tfstate"
+    region               = "ap-southeast-2"
+    dynamodb_table       = "koalasafe-terraform-locks"
+    encrypt              = true
+    workspace_key_prefix = "data-storage"
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/edge-frontend/.terraform.lock.hcl
+++ b/terraform/edge-frontend/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/edge-frontend/main.tf
+++ b/terraform/edge-frontend/main.tf
@@ -1,0 +1,51 @@
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_acm_certificate" "cert" {
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+}
+
+resource "aws_cloudfront_distribution" "cdn" {
+  enabled = true
+
+  origin {
+    domain_name = var.origin_domain_name
+    origin_id   = "origin"
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "origin"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    forwarded_values {
+      query_string = false
+      cookies { forward = "none" }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate.cert.arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+}
+
+resource "aws_route53_record" "alias" {
+  zone_id = var.hosted_zone_id
+  name    = var.domain_name
+  type    = "A"
+  alias {
+    name                   = aws_cloudfront_distribution.cdn.domain_name
+    zone_id                = aws_cloudfront_distribution.cdn.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/terraform/edge-frontend/outputs.tf
+++ b/terraform/edge-frontend/outputs.tf
@@ -1,0 +1,3 @@
+output "cloudfront_domain_name" {
+  value = aws_cloudfront_distribution.cdn.domain_name
+}

--- a/terraform/edge-frontend/variables.tf
+++ b/terraform/edge-frontend/variables.tf
@@ -1,0 +1,24 @@
+variable "name" {
+  type        = string
+  description = "Name prefix for resources"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region for ACM and Route53"
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Domain name for the frontend"
+}
+
+variable "origin_domain_name" {
+  type        = string
+  description = "Origin domain for CloudFront"
+}
+
+variable "hosted_zone_id" {
+  type        = string
+  description = "Route53 hosted zone ID"
+}

--- a/terraform/edge-frontend/versions.tf
+++ b/terraform/edge-frontend/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  backend "s3" {
+    bucket               = "koalasafe-terraform-state"
+    key                  = "terraform.tfstate"
+    region               = "ap-southeast-2"
+    dynamodb_table       = "koalasafe-terraform-locks"
+    encrypt              = true
+    workspace_key_prefix = "edge-frontend"
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/ingest-firehose/.terraform.lock.hcl
+++ b/terraform/ingest-firehose/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/ingest-firehose/main.tf
+++ b/terraform/ingest-firehose/main.tf
@@ -1,0 +1,46 @@
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_iam_role" "lambda_exec" {
+  name = "${var.name}-lambda-exec"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_lambda_function" "processor" {
+  function_name = "${var.name}-processor"
+  s3_bucket     = var.lambda_s3_bucket
+  s3_key        = var.lambda_s3_key
+  role          = aws_iam_role.lambda_exec.arn
+  handler       = "index.handler"
+  runtime       = "python3.11"
+}
+
+resource "aws_iam_role" "firehose" {
+  name = "${var.name}-firehose-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "firehose.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "stream" {
+  name        = "${var.name}-stream"
+  destination = "extended_s3"
+
+  extended_s3_configuration {
+    bucket_arn = var.delivery_bucket_arn
+    role_arn   = aws_iam_role.firehose.arn
+  }
+}

--- a/terraform/ingest-firehose/outputs.tf
+++ b/terraform/ingest-firehose/outputs.tf
@@ -1,0 +1,7 @@
+output "lambda_function_name" {
+  value = aws_lambda_function.processor.function_name
+}
+
+output "firehose_stream_arn" {
+  value = aws_kinesis_firehose_delivery_stream.stream.arn
+}

--- a/terraform/ingest-firehose/variables.tf
+++ b/terraform/ingest-firehose/variables.tf
@@ -1,0 +1,24 @@
+variable "name" {
+  type        = string
+  description = "Name prefix for resources"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region"
+}
+
+variable "lambda_s3_bucket" {
+  type        = string
+  description = "S3 bucket containing Lambda code"
+}
+
+variable "lambda_s3_key" {
+  type        = string
+  description = "S3 key for Lambda code"
+}
+
+variable "delivery_bucket_arn" {
+  type        = string
+  description = "Destination S3 bucket ARN for Firehose"
+}

--- a/terraform/ingest-firehose/versions.tf
+++ b/terraform/ingest-firehose/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  backend "s3" {
+    bucket               = "koalasafe-terraform-state"
+    key                  = "terraform.tfstate"
+    region               = "ap-southeast-2"
+    dynamodb_table       = "koalasafe-terraform-locks"
+    encrypt              = true
+    workspace_key_prefix = "ingest-firehose"
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold core infrastructure Terraform modules for network, ingest, compute, storage, and edge frontend
- configure S3/DynamoDB remote state with workspace prefixes for dev and prod

## Testing
- `terraform fmt -recursive terraform`
- `terraform init -backend=false && terraform validate` in each module
