### PR TITLE
Add GeoJSON processor task and scheduled ECS infrastructure

### DIFF
--- a/src/geojson_processor/Dockerfile
+++ b/src/geojson_processor/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gdal-bin libgdal-dev libgeos-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir boto3 fiona shapely
+
+WORKDIR /app
+COPY main.py /app/main.py
+
+ENTRYPOINT ["python", "main.py"]

--- a/src/geojson_processor/main.py
+++ b/src/geojson_processor/main.py
@@ -1,0 +1,51 @@
+import json
+import os
+import tempfile
+
+import boto3
+import fiona
+from shapely.geometry import shape, mapping
+from shapely.ops import unary_union
+
+
+def collect_firehose_geometries(s3_client, bucket: str, prefix: str):
+    """Load GeoJSON features from Firehose-delivered objects."""
+    geometries = []
+    resp = s3_client.list_objects_v2(Bucket=bucket, Prefix=prefix)
+    for obj in resp.get("Contents", []):
+        body = s3_client.get_object(Bucket=bucket, Key=obj["Key"])['Body'].read()
+        data = json.loads(body)
+        for feature in data.get("features", []):
+            geometries.append(shape(feature["geometry"]))
+    return geometries
+
+
+def main():
+    firehose_bucket = os.environ.get("FIREHOSE_BUCKET")
+    firehose_prefix = os.environ.get("FIREHOSE_PREFIX", "")
+    output_bucket = os.environ.get("OUTPUT_BUCKET")
+    output_key = os.environ.get("OUTPUT_KEY", "fire_perimeters.geojson")
+
+    if not firehose_bucket or not output_bucket:
+        raise RuntimeError("FIREHOSE_BUCKET and OUTPUT_BUCKET must be set")
+
+    s3 = boto3.client("s3")
+
+    geometries = collect_firehose_geometries(s3, firehose_bucket, firehose_prefix)
+    if not geometries:
+        print("No fire perimeter features found")
+        return
+
+    union_geom = unary_union(geometries)
+
+    schema = {"geometry": union_geom.geom_type, "properties": {}}
+
+    with tempfile.NamedTemporaryFile(suffix=".geojson", delete=False) as tmp:
+        with fiona.open(tmp.name, "w", driver="GeoJSON", schema=schema) as dst:
+            dst.write({"geometry": mapping(union_geom), "properties": {}})
+        s3.upload_file(tmp.name, output_bucket, output_key)
+        print(f"Uploaded merged perimeters to s3://{output_bucket}/{output_key}")
+
+
+if __name__ == "__main__":
+    main()

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/geojson_processor.tf
+++ b/terraform/geojson_processor.tf
@@ -1,0 +1,177 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+variable "firehose_bucket" {}
+variable "output_bucket" {}
+variable "cluster_arn" {}
+variable "subnet_ids" { type = list(string) }
+variable "security_group_ids" { type = list(string) }
+variable "prometheus_endpoint" {}
+variable "region" {}
+
+# IAM role for task with S3 access
+resource "aws_iam_role" "geojson_task" {
+  name               = "geojson-task-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume.json
+}
+
+data "aws_iam_policy_document" "ecs_task_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "geojson_s3" {
+  name   = "geojson-s3-access"
+  policy = data.aws_iam_policy_document.geojson_s3.json
+}
+
+data "aws_iam_policy_document" "geojson_s3" {
+  statement {
+    actions = ["s3:GetObject", "s3:PutObject", "s3:ListBucket"]
+    resources = [
+      "arn:aws:s3:::${var.firehose_bucket}",
+      "arn:aws:s3:::${var.firehose_bucket}/*",
+      "arn:aws:s3:::${var.output_bucket}",
+      "arn:aws:s3:::${var.output_bucket}/*"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "geojson_attach" {
+  role       = aws_iam_role.geojson_task.name
+  policy_arn = aws_iam_policy.geojson_s3.arn
+}
+
+# ECS task definition with ADOT sidecar
+resource "aws_ecs_task_definition" "geojson" {
+  family                   = "geojson-processor"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "512"
+  memory                   = "1024"
+  task_role_arn            = aws_iam_role.geojson_task.arn
+  execution_role_arn       = aws_iam_role.geojson_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "processor"
+      image     = "123456789012.dkr.ecr.${var.region}.amazonaws.com/geojson-processor:latest"
+      essential = true
+      environment = [
+        { name = "FIREHOSE_BUCKET", value = var.firehose_bucket },
+        { name = "OUTPUT_BUCKET", value = var.output_bucket }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = "/ecs/geojson-processor"
+          "awslogs-region"        = var.region
+          "awslogs-stream-prefix" = "ecs"
+        }
+      }
+    },
+    {
+      name      = "adot-collector"
+      image     = "public.ecr.aws/aws-observability/aws-otel-collector:latest"
+      essential = false
+      command   = ["--config=/etc/ecs/ecs-default-config.yaml"]
+      environment = [
+        {
+          name  = "AOT_CONFIG_CONTENT",
+          value = <<EOT
+receivers:
+  awsecscontainermetrics:
+  otlp:
+    protocols:
+      grpc:
+      http:
+exporters:
+  awsprometheusremotewrite:
+    endpoint: "${var.prometheus_endpoint}"
+service:
+  pipelines:
+    metrics:
+      receivers: [awsecscontainermetrics]
+      exporters: [awsprometheusremotewrite]
+    traces:
+      receivers: [otlp]
+      exporters: [awsprometheusremotewrite]
+EOT
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = "/ecs/geojson-processor"
+          "awslogs-region"        = var.region
+          "awslogs-stream-prefix" = "adot"
+        }
+      }
+    }
+  ])
+}
+
+# Schedule to run every 5 minutes
+resource "aws_cloudwatch_event_rule" "geojson_schedule" {
+  name                = "geojson-five-min"
+  schedule_expression = "cron(0/5 * * * ? *)"
+}
+
+resource "aws_iam_role" "events" {
+  name               = "geojson-events-role"
+  assume_role_policy = data.aws_iam_policy_document.events_assume.json
+}
+
+data "aws_iam_policy_document" "events_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "events_run_task" {
+  name   = "geojson-events-run-task"
+  role   = aws_iam_role.events.id
+  policy = data.aws_iam_policy_document.events_run_task.json
+}
+
+data "aws_iam_policy_document" "events_run_task" {
+  statement {
+    actions   = ["ecs:RunTask", "iam:PassRole"]
+    resources = [aws_ecs_task_definition.geojson.arn, aws_iam_role.geojson_task.arn]
+  }
+}
+
+resource "aws_cloudwatch_event_target" "geojson_target" {
+  rule     = aws_cloudwatch_event_rule.geojson_schedule.name
+  arn      = var.cluster_arn
+  role_arn = aws_iam_role.events.arn
+
+  ecs_target {
+    launch_type         = "FARGATE"
+    task_definition_arn = aws_ecs_task_definition.geojson.arn
+    network_configuration {
+      subnets          = var.subnet_ids
+      security_groups  = var.security_group_ids
+      assign_public_ip = false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Dockerize a GeoJSON processor that merges Kinesis Firehose data into `fire_perimeters.geojson` using Shapely and Fiona
- Terraform scheduled ECS Fargate task every 5 minutes with S3 access
- Added ADOT sidecar to export metrics and traces to Prometheus/Grafana

## Testing
- `python -m py_compile src/geojson_processor/main.py`
- `terraform init`
- `terraform validate`

