### PR TITLE
Add Route53 failover and budget alerting

### DIFF
--- a/terraform/budget.tf
+++ b/terraform/budget.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_sns_topic" "budget" {
+  name = "koalasafe-budget"
+}
+
+resource "aws_sns_topic_subscription" "slack" {
+  topic_arn = aws_sns_topic.budget.arn
+  protocol  = "https"
+  endpoint  = var.slack_webhook
+}
+
+resource "aws_budgets_budget" "monthly" {
+  name         = "koalasafe-monthly-budget"
+  budget_type  = "COST"
+  limit_amount = var.monthly_limit
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 80
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "FORECASTED"
+    subscriber_sns_topic_arns = [aws_sns_topic.budget.arn]
+  }
+}
+
+variable "region" {}
+variable "monthly_limit" {}
+variable "slack_webhook" {}

--- a/terraform/route53_failover.tf
+++ b/terraform/route53_failover.tf
@@ -1,0 +1,75 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_route53_health_check" "sydney" {
+  fqdn              = var.sydney_lb_dns
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = var.health_check_path
+  failure_threshold = 3
+  request_interval  = 30
+}
+
+resource "aws_route53_health_check" "melbourne" {
+  fqdn              = var.melbourne_lb_dns
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = var.health_check_path
+  failure_threshold = 3
+  request_interval  = 30
+}
+
+resource "aws_route53_record" "sydney" {
+  zone_id         = var.hosted_zone_id
+  name            = var.domain_name
+  type            = "A"
+  set_identifier  = "sydney"
+  health_check_id = aws_route53_health_check.sydney.id
+
+  weighted_routing_policy {
+    weight = 100
+  }
+
+  alias {
+    name                   = var.sydney_lb_dns
+    zone_id                = var.sydney_lb_zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "melbourne" {
+  zone_id         = var.hosted_zone_id
+  name            = var.domain_name
+  type            = "A"
+  set_identifier  = "melbourne"
+  health_check_id = aws_route53_health_check.melbourne.id
+
+  weighted_routing_policy {
+    weight = 0
+  }
+
+  alias {
+    name                   = var.melbourne_lb_dns
+    zone_id                = var.melbourne_lb_zone_id
+    evaluate_target_health = true
+  }
+}
+
+variable "region" {}
+variable "hosted_zone_id" {}
+variable "domain_name" {}
+variable "sydney_lb_dns" {}
+variable "sydney_lb_zone_id" {}
+variable "melbourne_lb_dns" {}
+variable "melbourne_lb_zone_id" {}
+variable "health_check_path" { default = "/" }


### PR DESCRIPTION
## Summary
- add Route53 health checks and weighted DNS records to enable regional failover
- provision budget alerting with SNS topic and Slack webhook

## Testing
- `terraform -chdir=/tmp/route53_test init -backend=false`
- `terraform -chdir=/tmp/route53_test validate`
- `terraform -chdir=/tmp/budget_test init -backend=false`
- `terraform -chdir=/tmp/budget_test validate`

