### PR TITLE
Add WAF protection for CloudFront distribution

### DIFF
--- a/terraform/edge-frontend/main.tf
+++ b/terraform/edge-frontend/main.tf
@@ -8,7 +8,8 @@ resource "aws_acm_certificate" "cert" {
 }
 
 resource "aws_cloudfront_distribution" "cdn" {
-  enabled = true
+  enabled    = true
+  web_acl_id = aws_wafv2_web_acl.waf.arn
 
   origin {
     domain_name = var.origin_domain_name

--- a/terraform/edge-frontend/waf.tf
+++ b/terraform/edge-frontend/waf.tf
@@ -1,0 +1,58 @@
+resource "aws_wafv2_web_acl" "waf" {
+  name  = "${var.name}-web-acl"
+  scope = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesBotControlRuleSet"
+    priority = 1
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesBotControlRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    override_action {
+      none {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "bot"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "rate-limit"
+    priority = 2
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        aggregate_key_type = "IP"
+        limit              = 1000
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "rate_limit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.name}-web-acl"
+    sampled_requests_enabled   = true
+  }
+}


### PR DESCRIPTION
## Summary
- add WAFv2 Web ACL with bot control and rate limiting rules
- attach the Web ACL to the existing CloudFront distribution

## Testing
- `terraform -chdir=terraform/edge-frontend fmt`
- `terraform -chdir=terraform/edge-frontend init -backend=false`
- `terraform -chdir=terraform/edge-frontend validate`


------
https://chatgpt.com/codex/tasks/task_e_688e53139aa08329b9d20ed48ba06413