### PR TITLE
feat: add cross region replication

### DIFF
--- a/terraform/data-storage/main.tf
+++ b/terraform/data-storage/main.tf
@@ -2,9 +2,101 @@ provider "aws" {
   region = var.region
 }
 
+provider "aws" {
+  alias  = "secondary"
+  region = var.secondary_region
+}
+
 resource "aws_s3_bucket" "data" {
   bucket        = "${var.name}-data-${terraform.workspace}"
   force_destroy = true
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    id      = "transition-ia"
+    enabled = true
+
+    transition {
+      days          = 7
+      storage_class = "STANDARD_IA"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "data_replica" {
+  provider      = aws.secondary
+  bucket        = "${var.name}-data-${terraform.workspace}-replica"
+  force_destroy = true
+
+  versioning {
+    enabled = true
+  }
+}
+
+data "aws_iam_policy_document" "replication_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "replication" {
+  name               = "${var.name}-replication-role-${terraform.workspace}"
+  assume_role_policy = data.aws_iam_policy_document.replication_assume.json
+}
+
+data "aws_iam_policy_document" "replication" {
+  statement {
+    actions = [
+      "s3:GetObjectVersionForReplication",
+      "s3:GetObjectVersionAcl",
+      "s3:GetObjectVersionTagging",
+      "s3:GetReplicationConfiguration",
+      "s3:ListBucket"
+    ]
+    resources = [
+      aws_s3_bucket.data.arn,
+      "${aws_s3_bucket.data.arn}/*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:ReplicateObject",
+      "s3:ReplicateDelete",
+      "s3:ReplicateTags",
+      "s3:GetObjectVersionTagging"
+    ]
+    resources = [
+      "${aws_s3_bucket.data_replica.arn}/*"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "replication" {
+  role   = aws_iam_role.replication.id
+  policy = data.aws_iam_policy_document.replication.json
+}
+
+resource "aws_s3_bucket_replication_configuration" "data" {
+  bucket = aws_s3_bucket.data.id
+  role   = aws_iam_role.replication.arn
+
+  rule {
+    id     = "replicate-to-secondary"
+    status = "Enabled"
+
+    destination {
+      bucket        = aws_s3_bucket.data_replica.arn
+      storage_class = "STANDARD"
+    }
+  }
 }
 
 resource "aws_dynamodb_table" "metadata" {
@@ -15,5 +107,9 @@ resource "aws_dynamodb_table" "metadata" {
   attribute {
     name = "id"
     type = "S"
+  }
+
+  replica {
+    region_name = var.secondary_region
   }
 }

--- a/terraform/data-storage/variables.tf
+++ b/terraform/data-storage/variables.tf
@@ -7,3 +7,8 @@ variable "region" {
   type        = string
   description = "AWS region"
 }
+
+variable "secondary_region" {
+  type        = string
+  description = "Secondary AWS region for replication"
+}


### PR DESCRIPTION
## Summary
- enable S3 versioning, lifecycle rule and cross-region replication to secondary region
- make DynamoDB table global across primary and secondary regions

## Testing
- `terraform -chdir=terraform/data-storage init -backend=false`
- `terraform -chdir=terraform/data-storage validate`
