### PR TITLE
chore: define Terraform and provider versions

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,17 +1,3 @@
-terraform {
-  required_version = ">= 1.3.0"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.0"
-    }
-    archive = {
-      source  = "hashicorp/archive"
-      version = "~> 2.0"
-    }
-  }
-}
-
 provider "aws" {
   region = var.region
 }

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2.0"
+    }
+  }
+}

--- a/terraform/alarms.tf
+++ b/terraform/alarms.tf
@@ -1,8 +1,9 @@
 terraform {
+  required_version = ">= 1.3.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/terraform/api_gateway/.terraform.lock.hcl
+++ b/terraform/api_gateway/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.7.1"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
+    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
+    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
+    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
+    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
+    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
+    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
+    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
+    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
+    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
+    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.7.0"
+  constraints = ">= 5.0.0"
+  hashes = [
+    "h1:MR1e3FM/ZMHBaUOsLJu2XIjkbogmh5q5IV/N73zGX14=",
+    "zh:3c0a256f813e5e2c1e1aa137204ad9168ebe487f6cee874af9e9c78eb300568e",
+    "zh:3c49dd75ea28395b29ba259988826b956c8adf6c0b59dd8874feb4f47bad976a",
+    "zh:3e6e3e3bfc6594f4f9e2c017ee588c5fcad394b87dd0b68a3f37cd66001f3c8c",
+    "zh:3f9b55826eeebf9b2ed448fc111d772c703e1edc6678e1bb646e66f3c3f9308f",
+    "zh:44e4ced936045ddc42d22c653a6427e7eb2b7aee918dff8438da0cb40996beb4",
+    "zh:474ab4d63918f41e8ea1cef43aeb1c719629dbf289db175c95de1431a8853ae7",
+    "zh:71b9e1d82c5ccc8d9bf72b3712c2b90722fc1f35a0f0f7a9557b9ee01971e6e2",
+    "zh:7723256d6ccc55f4000d1df8db202b02b30a7d917f5d31624c717e14ba15ea95",
+    "zh:82174836faa830aff0e47ea61d4cfbb5c97e1e944b1978f1d933acd37f584c88",
+    "zh:8e62fdc10206ba7232eec991e5a387378f2fbe47cc717b7f60eeb1df2c974514",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:be24dd2d53b224d7098e75ca432746e3420ce071189eea100aa8cbcd2498d389",
+    "zh:d27651d0e458933127ddca35a833e1a0f0ff0c131391288b3239763a2fd8f96f",
+    "zh:d33c181fff1b96bf8366e6c3d92408370b21649291e8f4d1f7e9a3fbb920fc9d",
+    "zh:edc0a0a84f85036c6d3df29d09557bd43206d9ee57b10542b484050f0f34d242",
+  ]
+}

--- a/terraform/api_gateway/main.tf
+++ b/terraform/api_gateway/main.tf
@@ -1,12 +1,3 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 5.0"
-    }
-  }
-}
-
 provider "aws" {
   region = var.region
 }
@@ -34,9 +25,9 @@ resource "aws_iam_role" "lambda" {
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
-      Effect = "Allow"
+      Effect    = "Allow"
       Principal = { Service = "lambda.amazonaws.com" }
-      Action = "sts:AssumeRole"
+      Action    = "sts:AssumeRole"
     }]
   })
 }
@@ -47,18 +38,18 @@ resource "aws_iam_role_policy_attachment" "lambda_basic" {
 }
 
 resource "aws_iam_role_policy" "lambda_extra" {
-  role   = aws_iam_role.lambda.id
+  role = aws_iam_role.lambda.id
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
-        Effect = "Allow"
-        Action = ["s3:GetObject"],
+        Effect   = "Allow"
+        Action   = ["s3:GetObject"],
         Resource = "arn:aws:s3:::${var.geojson_bucket}/${var.geojson_key}"
       },
       {
-        Effect = "Allow"
-        Action = ["dynamodb:PutItem", "dynamodb:DeleteItem"],
+        Effect   = "Allow"
+        Action   = ["dynamodb:PutItem", "dynamodb:DeleteItem"],
         Resource = "arn:aws:dynamodb:*:*:table/${var.alerts_table_name}"
       }
     ]
@@ -66,11 +57,11 @@ resource "aws_iam_role_policy" "lambda_extra" {
 }
 
 resource "aws_lambda_function" "geojson_proxy" {
-  function_name = "geojsonProxyFn"
-  handler       = "geojson_proxy.geojsonProxyFn"
-  runtime       = "python3.12"
-  role          = aws_iam_role.lambda.arn
-  filename      = data.archive_file.geojson_proxy.output_path
+  function_name    = "geojsonProxyFn"
+  handler          = "geojson_proxy.geojsonProxyFn"
+  runtime          = "python3.12"
+  role             = aws_iam_role.lambda.arn
+  filename         = data.archive_file.geojson_proxy.output_path
   source_code_hash = data.archive_file.geojson_proxy.output_base64sha256
   environment {
     variables = {
@@ -81,11 +72,11 @@ resource "aws_lambda_function" "geojson_proxy" {
 }
 
 resource "aws_lambda_function" "subscribe" {
-  function_name = "subscribeFn"
-  handler       = "subscribe.subscribeFn"
-  runtime       = "python3.12"
-  role          = aws_iam_role.lambda.arn
-  filename      = data.archive_file.subscribe.output_path
+  function_name    = "subscribeFn"
+  handler          = "subscribe.subscribeFn"
+  runtime          = "python3.12"
+  role             = aws_iam_role.lambda.arn
+  filename         = data.archive_file.subscribe.output_path
   source_code_hash = data.archive_file.subscribe.output_base64sha256
   environment {
     variables = {
@@ -95,11 +86,11 @@ resource "aws_lambda_function" "subscribe" {
 }
 
 resource "aws_lambda_function" "unsubscribe" {
-  function_name = "unsubscribeFn"
-  handler       = "unsubscribe.unsubscribeFn"
-  runtime       = "python3.12"
-  role          = aws_iam_role.lambda.arn
-  filename      = data.archive_file.unsubscribe.output_path
+  function_name    = "unsubscribeFn"
+  handler          = "unsubscribe.unsubscribeFn"
+  runtime          = "python3.12"
+  role             = aws_iam_role.lambda.arn
+  filename         = data.archive_file.unsubscribe.output_path
   source_code_hash = data.archive_file.unsubscribe.output_base64sha256
   environment {
     variables = {
@@ -144,17 +135,17 @@ resource "aws_api_gateway_resource" "alert" {
 }
 
 resource "aws_api_gateway_authorizer" "cognito" {
-  name        = "cognito-authorizer"
-  rest_api_id = aws_api_gateway_rest_api.api.id
-  type        = "COGNITO_USER_POOLS"
+  name          = "cognito-authorizer"
+  rest_api_id   = aws_api_gateway_rest_api.api.id
+  type          = "COGNITO_USER_POOLS"
   provider_arns = [var.cognito_user_pool_arn]
 }
 
 resource "aws_api_gateway_method" "get_latest" {
-  rest_api_id   = aws_api_gateway_rest_api.api.id
-  resource_id   = aws_api_gateway_resource.latest.id
-  http_method   = "GET"
-  authorization = "NONE"
+  rest_api_id      = aws_api_gateway_rest_api.api.id
+  resource_id      = aws_api_gateway_resource.latest.id
+  http_method      = "GET"
+  authorization    = "NONE"
   api_key_required = true
 }
 

--- a/terraform/api_gateway/versions.tf
+++ b/terraform/api_gateway/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2.0"
+    }
+  }
+}

--- a/terraform/compute-fargate/versions.tf
+++ b/terraform/compute-fargate/versions.tf
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/terraform/core-network/versions.tf
+++ b/terraform/core-network/versions.tf
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/terraform/data-storage/versions.tf
+++ b/terraform/data-storage/versions.tf
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/terraform/edge-frontend/versions.tf
+++ b/terraform/edge-frontend/versions.tf
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/terraform/geojson_processor.tf
+++ b/terraform/geojson_processor.tf
@@ -1,8 +1,9 @@
 terraform {
+  required_version = ">= 1.3.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/terraform/ingest-firehose/versions.tf
+++ b/terraform/ingest-firehose/versions.tf
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add versions.tf for infra and API Gateway modules
- require aws>=5.0 and archive>=2.0 providers
- align existing modules on aws>=5.0

## Testing
- `terraform fmt -recursive`
- `terraform -chdir=infra init -backend=false`
- `terraform -chdir=infra validate`
- `terraform -chdir=terraform/api_gateway init -backend=false`
- `terraform -chdir=terraform/api_gateway validate`
- `terraform -chdir=terraform/data-storage init -backend=false`
- `terraform -chdir=terraform/data-storage validate`
- `terraform -chdir=terraform/edge-frontend init -backend=false`
- `terraform -chdir=terraform/edge-frontend validate`
- `terraform -chdir=terraform/ingest-firehose init -backend=false`
- `terraform -chdir=terraform/ingest-firehose validate`
- `terraform -chdir=terraform/compute-fargate init -backend=false`
- `terraform -chdir=terraform/compute-fargate validate`
- `terraform -chdir=terraform/core-network init -backend=false`
- `terraform -chdir=terraform/core-network validate`
- `terraform -chdir=/tmp/terraform_alarms init -backend=false`
- `terraform -chdir=/tmp/terraform_alarms validate`
- `terraform -chdir=/tmp/terraform_geojson init -backend=false`
- `terraform -chdir=/tmp/terraform_geojson validate`

