### PR TITLE
feat: configure terraform backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,24 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        workspace: [dev, prod]
+    env:
+      TF_WORKSPACE: ${{ matrix.workspace }}
     steps:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.5.0
       - uses: instrumenta/setup-conftest@v1
-      - run: terraform init
-      - run: terraform plan -out=tfplan
-      - run: terraform show -json tfplan > tfplan.json
-      - run: conftest test tfplan.json
+      - name: Terraform Init
+        run: terraform -chdir=terraform init
+      - name: Select Workspace
+        run: terraform -chdir=terraform workspace select $TF_WORKSPACE || terraform -chdir=terraform workspace new $TF_WORKSPACE
+      - name: Terraform Plan
+        run: terraform -chdir=terraform plan -out=tfplan
+      - name: Show Plan JSON
+        run: terraform -chdir=terraform show -json tfplan > tfplan.json
+      - name: Conftest
+        run: conftest test tfplan.json

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -51,6 +51,8 @@ jobs:
         uses: hashicorp/setup-terraform@v2
       - name: Terraform Init
         run: terraform -chdir=terraform init
+      - name: Select Workspace
+        run: terraform -chdir=terraform workspace select prod || terraform -chdir=terraform workspace new prod
       - name: Terraform Plan
         run: terraform -chdir=terraform plan
       - name: Terraform Apply

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "koalasafe-tfstate"
+    key            = "terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "koalasafe-tfstate-lock"
+    encrypt        = true
+  }
+}


### PR DESCRIPTION
## Summary
- configure Terraform S3 backend with DynamoDB locking
- run Terraform in dev and prod workspaces during CI
- use prod workspace for production deployment

## Testing
- `terraform -chdir=terraform fmt`
- `terraform -chdir=terraform init -backend=false` *(fails: Duplicate required providers configuration)*

