### PR TITLE
feat: add networking resources

### DIFF
--- a/terraform/core-network/main.tf
+++ b/terraform/core-network/main.tf
@@ -29,3 +29,86 @@ resource "aws_subnet" "private" {
     Name = "${var.name}-private-${count.index}"
   }
 }
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.name}-igw"
+  }
+}
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+}
+
+resource "aws_nat_gateway" "this" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public[var.nat_gateway_subnet_index].id
+
+  tags = {
+    Name = "${var.name}-nat"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = {
+    Name = "${var.name}-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(aws_subnet.public)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.this.id
+  }
+
+  tags = {
+    Name = "${var.name}-private-rt"
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(aws_subnet.private)
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_security_group" "default" {
+  name        = "${var.name}-sg"
+  description = "Default security group for core network"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = var.security_group_ingress_cidr_blocks
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.name}-sg"
+  }
+}

--- a/terraform/core-network/outputs.tf
+++ b/terraform/core-network/outputs.tf
@@ -9,3 +9,23 @@ output "public_subnet_ids" {
 output "private_subnet_ids" {
   value = aws_subnet.private[*].id
 }
+
+output "internet_gateway_id" {
+  value = aws_internet_gateway.this.id
+}
+
+output "nat_gateway_id" {
+  value = aws_nat_gateway.this.id
+}
+
+output "public_route_table_id" {
+  value = aws_route_table.public.id
+}
+
+output "private_route_table_id" {
+  value = aws_route_table.private.id
+}
+
+output "security_group_id" {
+  value = aws_security_group.default.id
+}

--- a/terraform/core-network/variables.tf
+++ b/terraform/core-network/variables.tf
@@ -27,3 +27,15 @@ variable "availability_zones" {
   type        = list(string)
   description = "Availability zones for subnets"
 }
+
+variable "nat_gateway_subnet_index" {
+  type        = number
+  description = "Index of the public subnet in which to place the NAT Gateway"
+  default     = 0
+}
+
+variable "security_group_ingress_cidr_blocks" {
+  type        = list(string)
+  description = "CIDR blocks allowed to access the default security group"
+  default     = ["0.0.0.0/0"]
+}


### PR DESCRIPTION
## Summary
- build out core networking with internet/NAT gateways and route tables
- expose networking IDs for downstream modules

## Testing
- `terraform init -backend=false`
- `terraform validate -no-color`

