### PR TITLE
refactor(terraform): use modules and env auth

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,207 +8,53 @@ terraform {
 }
 
 provider "aws" {
-  region                      = "us-east-1"
-  access_key                  = "mock"
-  secret_key                  = "mock"
-  skip_credentials_validation = true
-  skip_requesting_account_id  = true
-  skip_metadata_api_check     = true
-  skip_region_validation      = true
-  s3_use_path_style           = true
+  region = var.region
 }
 
-# KMS key for encrypting resources
-resource "aws_kms_key" "main" {
-  description             = "KMS key for encrypting resources"
-  deletion_window_in_days = 7
+module "core_network" {
+  source = "./core-network"
+
+  name                 = var.name
+  region               = var.region
+  vpc_cidr             = var.vpc_cidr
+  public_subnet_cidrs  = var.public_subnet_cidrs
+  private_subnet_cidrs = var.private_subnet_cidrs
+  availability_zones   = var.availability_zones
 }
 
-# S3 bucket for application data
-resource "aws_s3_bucket" "app" {
-  bucket = "app-data-bucket-example"
+module "data_storage" {
+  source = "./data-storage"
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = aws_kms_key.main.arn
-        sse_algorithm     = "aws:kms"
-      }
-    }
-  }
+  name             = var.name
+  region           = var.region
+  secondary_region = var.secondary_region
 }
 
-# S3 bucket for CloudFront logs
-resource "aws_s3_bucket" "logs" {
-  bucket = "cloudfront-logs-bucket-example"
+module "ingest_firehose" {
+  source = "./ingest-firehose"
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = aws_kms_key.main.arn
-        sse_algorithm     = "aws:kms"
-      }
-    }
-  }
+  name                = var.name
+  region              = var.region
+  lambda_s3_bucket    = var.lambda_s3_bucket
+  lambda_s3_key       = var.lambda_s3_key
+  delivery_bucket_arn = var.delivery_bucket_arn
 }
 
-# SNS topic with KMS encryption
-resource "aws_sns_topic" "alerts" {
-  name              = "alerts-topic"
-  kms_master_key_id = aws_kms_key.main.arn
+module "compute_fargate" {
+  source = "./compute-fargate"
+
+  name               = var.name
+  region             = var.region
+  subnet_ids         = module.core_network.private_subnet_ids
+  security_group_ids = var.security_group_ids
 }
 
-# DynamoDB table with KMS encryption
-resource "aws_dynamodb_table" "items" {
-  name         = "items"
-  billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "id"
+module "edge_frontend" {
+  source = "./edge-frontend"
 
-  attribute {
-    name = "id"
-    type = "S"
-  }
-
-  server_side_encryption {
-    enabled     = true
-    kms_key_arn = aws_kms_key.main.arn
-  }
-}
-
-# IAM role for Lambda with minimal permissions
-resource "aws_iam_role" "lambda_role" {
-  name               = "lambda-basic-role"
-  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
-}
-
-data "aws_iam_policy_document" "lambda_assume" {
-  statement {
-    actions = ["sts:AssumeRole"]
-    principals {
-      type        = "Service"
-      identifiers = ["lambda.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_role_policy" "lambda_policy" {
-  name   = "lambda-basic-policy"
-  role   = aws_iam_role.lambda_role.id
-  policy = data.aws_iam_policy_document.lambda_policy.json
-}
-
-data "aws_iam_policy_document" "lambda_policy" {
-  statement {
-    actions   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
-    resources = ["arn:aws:logs:*:*:*"]
-  }
-  statement {
-    actions   = ["s3:GetObject"]
-    resources = [aws_s3_bucket.app.arn, "${aws_s3_bucket.app.arn}/*"]
-  }
-}
-
-# IAM role for ECS task with minimal permissions
-resource "aws_iam_role" "ecs_task_role" {
-  name               = "ecs-task-role"
-  assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
-}
-
-data "aws_iam_policy_document" "ecs_assume" {
-  statement {
-    actions = ["sts:AssumeRole"]
-    principals {
-      type        = "Service"
-      identifiers = ["ecs-tasks.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_role_policy" "ecs_policy" {
-  name   = "ecs-task-policy"
-  role   = aws_iam_role.ecs_task_role.id
-  policy = data.aws_iam_policy_document.ecs_policy.json
-}
-
-data "aws_iam_policy_document" "ecs_policy" {
-  statement {
-    actions   = ["dynamodb:PutItem", "dynamodb:GetItem"]
-    resources = [aws_dynamodb_table.items.arn]
-  }
-  statement {
-    actions   = ["s3:GetObject"]
-    resources = [aws_s3_bucket.app.arn, "${aws_s3_bucket.app.arn}/*"]
-  }
-}
-
-# WAF Web ACL with rate limiting
-resource "aws_wafv2_web_acl" "main" {
-  name  = "rate-limit-acl"
-  scope = "CLOUDFRONT"
-
-  default_action {
-    allow {}
-  }
-
-  visibility_config {
-    cloudwatch_metrics_enabled = false
-    metric_name                = "waf"
-    sampled_requests_enabled   = false
-  }
-
-  rule {
-    name     = "rate-limit-rule"
-    priority = 1
-
-    action {
-      block {}
-    }
-
-    statement {
-      rate_based_statement {
-        limit              = 1000
-        aggregate_key_type = "IP"
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = false
-      metric_name                = "rate-limit"
-      sampled_requests_enabled   = false
-    }
-  }
-}
-
-# CloudFront distribution with WAF and logging
-resource "aws_cloudfront_distribution" "cdn" {
-  enabled             = true
-  default_root_object = "index.html"
-
-  origin {
-    domain_name = aws_s3_bucket.app.bucket_regional_domain_name
-    origin_id   = "s3-app"
-  }
-
-  default_cache_behavior {
-    allowed_methods        = ["GET", "HEAD"]
-    cached_methods         = ["GET", "HEAD"]
-    target_origin_id       = "s3-app"
-    viewer_protocol_policy = "redirect-to-https"
-  }
-
-  restrictions {
-    geo_restriction {
-      restriction_type = "none"
-    }
-  }
-
-  viewer_certificate {
-    cloudfront_default_certificate = true
-  }
-
-  logging_config {
-    bucket = aws_s3_bucket.logs.bucket_domain_name
-  }
-
-  web_acl_id = aws_wafv2_web_acl.main.arn
+  name               = var.name
+  region             = var.region
+  domain_name        = var.domain_name
+  origin_domain_name = var.origin_domain_name
+  hosted_zone_id     = var.hosted_zone_id
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,69 @@
+variable "name" {
+  type        = string
+  description = "Name prefix for resources"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region"
+}
+
+variable "secondary_region" {
+  type        = string
+  description = "Secondary AWS region for replication"
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "CIDR block for the VPC"
+}
+
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "CIDR blocks for public subnets"
+}
+
+variable "private_subnet_cidrs" {
+  type        = list(string)
+  description = "CIDR blocks for private subnets"
+}
+
+variable "availability_zones" {
+  type        = list(string)
+  description = "Availability zones for subnets"
+}
+
+variable "lambda_s3_bucket" {
+  type        = string
+  description = "S3 bucket containing Lambda code"
+}
+
+variable "lambda_s3_key" {
+  type        = string
+  description = "S3 key for Lambda code"
+}
+
+variable "delivery_bucket_arn" {
+  type        = string
+  description = "Destination S3 bucket ARN for Firehose"
+}
+
+variable "security_group_ids" {
+  type        = list(string)
+  description = "Security groups for compute resources"
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Domain name for the frontend"
+}
+
+variable "origin_domain_name" {
+  type        = string
+  description = "Origin domain for CloudFront"
+}
+
+variable "hosted_zone_id" {
+  type        = string
+  description = "Route53 hosted zone ID"
+}


### PR DESCRIPTION
## Summary
- remove static AWS credentials from Terraform provider and rely on environment/role-based auth
- orchestrate infrastructure using core-network, data-storage, ingest-firehose, compute-fargate and edge-frontend modules
- centralize module inputs in new variables.tf

## Testing
- `terraform fmt`
- `terraform validate` *(fails: Duplicate provider/variable declarations across multiple files)*
