### PR TITLE
Expand unit test coverage and CI execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,15 @@ on:
   pull_request:
 
 jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install -r requirements.txt pytest
+      - run: pytest
   validate:
     runs-on: ubuntu-latest
     strategy:

--- a/tests/test_geojson_proxy.py
+++ b/tests/test_geojson_proxy.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import json
+import io
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from api import geojson_proxy
+
+
+def test_geojson_proxy_no_bucket(monkeypatch=None):
+    os.environ.pop("GEOJSON_BUCKET", None)
+    response = geojson_proxy.geojsonProxyFn({}, None)
+    assert response["statusCode"] == 500
+    body = json.loads(response["body"])
+    assert body["error"] == "GEOJSON_BUCKET not set"
+
+
+def test_geojson_proxy_success(monkeypatch=None):
+    os.environ["GEOJSON_BUCKET"] = "my-bucket"
+    os.environ["GEOJSON_KEY"] = "data.geojson"
+    sample = {"type": "FeatureCollection"}
+    mock_body = io.BytesIO(json.dumps(sample).encode("utf-8"))
+    with patch.object(geojson_proxy.s3, "get_object", return_value={"Body": mock_body}) as mock_get:
+        response = geojson_proxy.geojsonProxyFn({}, None)
+    mock_get.assert_called_once_with(Bucket="my-bucket", Key="data.geojson")
+    assert response["statusCode"] == 200
+    assert json.loads(response["body"]) == sample

--- a/tests/test_push_bridge.py
+++ b/tests/test_push_bridge.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import importlib
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+push_bridge = importlib.import_module("lambda.push_bridge")
+
+
+def _mock_urlopen():
+    mock = MagicMock()
+    mock.__enter__.return_value.read.return_value = b""
+    mock.__exit__.return_value = False
+    return mock
+
+
+def test_push_bridge_with_token():
+    push_bridge.EXPO_TOKEN = "token123"
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen()) as mock_open:
+        event = {"detail": {"device_token": "d1", "fence_id": "f1"}}
+        result = push_bridge.lambda_handler(event, None)
+    request = mock_open.call_args[0][0]
+    assert request.headers["Authorization"] == "Bearer token123"
+    assert result == {"status": "sent"}
+
+
+def test_push_bridge_without_token():
+    push_bridge.EXPO_TOKEN = None
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen()) as mock_open:
+        event = {"detail": {"device_token": "d1", "fence_id": "f1"}}
+        result = push_bridge.lambda_handler(event, None)
+    request = mock_open.call_args[0][0]
+    assert "Authorization" not in request.headers
+    assert result == {"status": "sent"}

--- a/tests/test_rule_eval.py
+++ b/tests/test_rule_eval.py
@@ -1,0 +1,61 @@
+import os
+import sys
+import json
+import importlib
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+
+rule_eval = importlib.import_module("lambda.rule_eval")
+
+
+def test_rule_eval_publishes_events():
+    mock_eventbridge = MagicMock()
+    rule_eval.eventbridge = mock_eventbridge
+    event = {
+        "Records": [
+            {
+                "eventName": "INSERT",
+                "dynamodb": {
+                    "NewImage": {
+                        "intersects": {"BOOL": True},
+                        "region": {"S": "r1"},
+                        "fence_id": {"S": "f1"},
+                    }
+                },
+            },
+            {
+                "eventName": "REMOVE",
+                "dynamodb": {
+                    "NewImage": {"intersects": {"BOOL": True}},
+                },
+            },
+            {
+                "eventName": "MODIFY",
+                "dynamodb": {
+                    "NewImage": {"intersects": {"BOOL": False}},
+                },
+            },
+        ]
+    }
+    result = rule_eval.lambda_handler(event, None)
+    mock_eventbridge.put_events.assert_called_once()
+    entries = mock_eventbridge.put_events.call_args[1]["Entries"]
+    assert entries == [
+        {
+            "Source": "koalasafe.rule_eval",
+            "DetailType": "FenceIntersection",
+            "Detail": json.dumps({"fence_id": "f1", "region": "r1"}),
+        }
+    ]
+    assert result == {"events_published": 1}
+
+
+def test_rule_eval_no_events():
+    mock_eventbridge = MagicMock()
+    rule_eval.eventbridge = mock_eventbridge
+    result = rule_eval.lambda_handler({"Records": []}, None)
+    mock_eventbridge.put_events.assert_not_called()
+    assert result == {"events_published": 0}

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import json
+from unittest.mock import MagicMock, patch
+from botocore.exceptions import ClientError
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from api import subscribe, unsubscribe
+
+
+def test_subscribe_stores_alert(monkeypatch=None):
+    os.environ["ALERTS_TABLE"] = "alerts"
+    event = {
+        "requestContext": {"authorizer": {"claims": {"sub": "user1"}}},
+        "body": json.dumps({"type": "fire"}),
+    }
+    mock_table = MagicMock()
+    with patch.object(subscribe.dynamodb, "Table", return_value=mock_table):
+        with patch("uuid.uuid4", return_value="uuid1"):
+            response = subscribe.subscribeFn(event, None)
+    mock_table.put_item.assert_called_once_with(
+        Item={"id": "uuid1", "user_id": "user1", "params": {"type": "fire"}}
+    )
+    assert response["statusCode"] == 201
+    assert json.loads(response["body"]) == {"id": "uuid1"}
+
+
+def test_unsubscribe_deletes_alert(monkeypatch=None):
+    os.environ["ALERTS_TABLE"] = "alerts"
+    event = {
+        "requestContext": {"authorizer": {"claims": {"sub": "user1"}}},
+        "pathParameters": {"id": "alert1"},
+    }
+    mock_table = MagicMock()
+    with patch.object(unsubscribe.dynamodb, "Table", return_value=mock_table):
+        response = unsubscribe.unsubscribeFn(event, None)
+    mock_table.delete_item.assert_called_once_with(
+        Key={"id": "alert1"},
+        ConditionExpression="user_id = :u",
+        ExpressionAttributeValues={":u": "user1"},
+    )
+    assert response["statusCode"] == 204
+
+
+def test_unsubscribe_not_found(monkeypatch=None):
+    os.environ["ALERTS_TABLE"] = "alerts"
+    event = {
+        "requestContext": {"authorizer": {"claims": {"sub": "user1"}}},
+        "pathParameters": {"id": "alert1"},
+    }
+    mock_table = MagicMock()
+    error_response = {"Error": {"Code": "ConditionalCheckFailedException"}}
+    mock_table.delete_item.side_effect = ClientError(error_response, "DeleteItem")
+    with patch.object(unsubscribe.dynamodb, "Table", return_value=mock_table):
+        response = unsubscribe.unsubscribeFn(event, None)
+    assert response["statusCode"] == 404
+    body = json.loads(response["body"])
+    assert body["error"] == "alert not found"


### PR DESCRIPTION
## Summary
- add unit tests for GeoJSON proxy and subscription APIs
- cover rule evaluation and push bridge lambdas with mocked AWS services
- run Python unit tests in CI workflow

## Testing
- `pytest -q`

