### PR TITLE
Enable server-side encryption for data buckets

### DIFF
--- a/terraform/data-storage/main.tf
+++ b/terraform/data-storage/main.tf
@@ -15,6 +15,14 @@ resource "aws_s3_bucket" "data" {
     enabled = true
   }
 
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
   lifecycle_rule {
     id      = "transition-ia"
     enabled = true
@@ -33,6 +41,14 @@ resource "aws_s3_bucket" "data_replica" {
 
   versioning {
     enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- enforce default AES256 encryption on primary and replica S3 data buckets

## Testing
- `terraform -chdir=terraform/data-storage init -backend=false`
- `terraform -chdir=terraform/data-storage validate`
- `AWS_ACCESS_KEY_ID=mock AWS_SECRET_ACCESS_KEY=mock AWS_DEFAULT_REGION=us-east-1 terraform -chdir=terraform/data-storage plan` *(fails: Backend initialization required)*

