### PR TITLE
chore(terraform): centralize backend configuration

### DIFF
--- a/terraform/compute-fargate/versions.tf
+++ b/terraform/compute-fargate/versions.tf
@@ -1,15 +1,6 @@
 terraform {
   required_version = ">= 1.0.0"
 
-  backend "s3" {
-    bucket               = "koalasafe-terraform-state"
-    key                  = "terraform.tfstate"
-    region               = "ap-southeast-2"
-    dynamodb_table       = "koalasafe-terraform-locks"
-    encrypt              = true
-    workspace_key_prefix = "compute-fargate"
-  }
-
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/core-network/versions.tf
+++ b/terraform/core-network/versions.tf
@@ -1,15 +1,6 @@
 terraform {
   required_version = ">= 1.0.0"
 
-  backend "s3" {
-    bucket               = "koalasafe-terraform-state"
-    key                  = "terraform.tfstate"
-    region               = "ap-southeast-2"
-    dynamodb_table       = "koalasafe-terraform-locks"
-    encrypt              = true
-    workspace_key_prefix = "core-network"
-  }
-
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/data-storage/versions.tf
+++ b/terraform/data-storage/versions.tf
@@ -1,15 +1,6 @@
 terraform {
   required_version = ">= 1.0.0"
 
-  backend "s3" {
-    bucket               = "koalasafe-terraform-state"
-    key                  = "terraform.tfstate"
-    region               = "ap-southeast-2"
-    dynamodb_table       = "koalasafe-terraform-locks"
-    encrypt              = true
-    workspace_key_prefix = "data-storage"
-  }
-
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/edge-frontend/versions.tf
+++ b/terraform/edge-frontend/versions.tf
@@ -1,15 +1,6 @@
 terraform {
   required_version = ">= 1.0.0"
 
-  backend "s3" {
-    bucket               = "koalasafe-terraform-state"
-    key                  = "terraform.tfstate"
-    region               = "ap-southeast-2"
-    dynamodb_table       = "koalasafe-terraform-locks"
-    encrypt              = true
-    workspace_key_prefix = "edge-frontend"
-  }
-
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/ingest-firehose/versions.tf
+++ b/terraform/ingest-firehose/versions.tf
@@ -1,15 +1,6 @@
 terraform {
   required_version = ">= 1.0.0"
 
-  backend "s3" {
-    bucket               = "koalasafe-terraform-state"
-    key                  = "terraform.tfstate"
-    region               = "ap-southeast-2"
-    dynamodb_table       = "koalasafe-terraform-locks"
-    encrypt              = true
-    workspace_key_prefix = "ingest-firehose"
-  }
-
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
## Summary
- remove backend blocks from module `versions.tf`
- rely on root `backend.tf` for remote state configuration

## Testing
- `terraform -chdir=terraform/ingest-firehose init -backend=false`
- `terraform -chdir=terraform/ingest-firehose validate -no-color`
- `terraform -chdir=terraform/compute-fargate init -backend=false -no-color`
- `terraform -chdir=terraform/compute-fargate validate -no-color 2>&1 | tail -n 20`
- `terraform -chdir=terraform/core-network init -backend=false -no-color`
- `terraform -chdir=terraform/core-network validate -no-color`
- `terraform -chdir=terraform/edge-frontend init -backend=false -no-color`
- `terraform -chdir=terraform/edge-frontend validate -no-color 2>&1 | tail -n 20`
- `terraform -chdir=terraform/data-storage init -backend=false -no-color`
- `terraform -chdir=terraform/data-storage validate -no-color`

