### PR TITLE
chore: wire data bucket arn and security group

### DIFF
--- a/terraform/data-storage/outputs.tf
+++ b/terraform/data-storage/outputs.tf
@@ -5,3 +5,7 @@ output "bucket_name" {
 output "dynamodb_table_name" {
   value = aws_dynamodb_table.metadata.name
 }
+
+output "bucket_arn" {
+  value = aws_s3_bucket.data.arn
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -37,7 +37,7 @@ module "ingest_firehose" {
   region              = var.region
   lambda_s3_bucket    = var.lambda_s3_bucket
   lambda_s3_key       = var.lambda_s3_key
-  delivery_bucket_arn = var.delivery_bucket_arn
+  delivery_bucket_arn = module.data_storage.bucket_arn
 }
 
 module "compute_fargate" {
@@ -46,7 +46,7 @@ module "compute_fargate" {
   name               = var.name
   region             = var.region
   subnet_ids         = module.core_network.private_subnet_ids
-  security_group_ids = var.security_group_ids
+  security_group_ids = [module.core_network.security_group_id]
 }
 
 module "edge_frontend" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -43,15 +43,6 @@ variable "lambda_s3_key" {
   description = "S3 key for Lambda code"
 }
 
-variable "delivery_bucket_arn" {
-  type        = string
-  description = "Destination S3 bucket ARN for Firehose"
-}
-
-variable "security_group_ids" {
-  type        = list(string)
-  description = "Security groups for compute resources"
-}
 
 variable "domain_name" {
   type        = string


### PR DESCRIPTION
## Summary
- export data bucket ARN and use it for Firehose delivery
- source Fargate security group from core_network module
- drop unused root variables

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false -no-color` *(fails: duplicate providers and variables)*
- `terraform validate -no-color` *(fails: duplicate providers and variables)*

