### PR TITLE
Add Prometheus endpoint variable for Fargate module

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -43,10 +43,11 @@ module "ingest_firehose" {
 module "compute_fargate" {
   source = "./compute-fargate"
 
-  name               = var.name
-  region             = var.region
-  subnet_ids         = module.core_network.private_subnet_ids
-  security_group_ids = [module.core_network.security_group_id]
+  name                = var.name
+  region              = var.region
+  subnet_ids          = module.core_network.private_subnet_ids
+  security_group_ids  = [module.core_network.security_group_id]
+  prometheus_endpoint = var.prometheus_endpoint
 }
 
 module "edge_frontend" {

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -1,0 +1,2 @@
+prometheus_endpoint = "https://prometheus.example.com"
+

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -58,3 +58,8 @@ variable "hosted_zone_id" {
   type        = string
   description = "Route53 hosted zone ID"
 }
+
+variable "prometheus_endpoint" {
+  type        = string
+  description = "Remote write endpoint for Prometheus metrics"
+}


### PR DESCRIPTION
## Summary
- add `prometheus_endpoint` variable and sample `prod.tfvars`
- wire the endpoint through root module into `compute_fargate`

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false` *(fails: Duplicate required providers configuration)*
- `terraform validate` *(fails: Duplicate required providers configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688e6333dd888329801462ad695b2d23