### PR TITLE
Add API Gateway module

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -49,6 +49,15 @@ module "compute_fargate" {
   security_group_ids = [module.core_network.security_group_id]
 }
 
+module "api_gateway" {
+  source = "./api_gateway"
+
+  region                = var.region
+  alerts_table_name     = var.alerts_table_name
+  geojson_bucket        = var.geojson_bucket
+  cognito_user_pool_arn = var.cognito_user_pool_arn
+}
+
 module "edge_frontend" {
   source = "./edge-frontend"
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -58,3 +58,18 @@ variable "hosted_zone_id" {
   type        = string
   description = "Route53 hosted zone ID"
 }
+
+variable "alerts_table_name" {
+  type        = string
+  description = "DynamoDB table for alert subscriptions"
+}
+
+variable "geojson_bucket" {
+  type        = string
+  description = "S3 bucket containing latest GeoJSON"
+}
+
+variable "cognito_user_pool_arn" {
+  type        = string
+  description = "ARN of Cognito User Pool"
+}


### PR DESCRIPTION
## Summary
- add api gateway module with S3, DynamoDB, and Cognito configuration variables

## Testing
- `terraform fmt terraform/main.tf terraform/variables.tf`
- `terraform -chdir=terraform init -backend=false` *(fails: Duplicate required providers configuration)*
