### PR TITLE
Add geo-fence alerts pipeline

### DIFF
--- a/terraform/api_gateway/main.tf
+++ b/terraform/api_gateway/main.tf
@@ -50,7 +50,7 @@ resource "aws_iam_role_policy" "lambda_extra" {
       {
         Effect   = "Allow"
         Action   = ["dynamodb:PutItem", "dynamodb:DeleteItem"],
-        Resource = "arn:aws:dynamodb:*:*:table/${var.alerts_table_name}"
+        Resource = "arn:aws:dynamodb:*:*:table/${var.geo_fences_table_name}"
       }
     ]
   })
@@ -80,7 +80,7 @@ resource "aws_lambda_function" "subscribe" {
   source_code_hash = data.archive_file.subscribe.output_base64sha256
   environment {
     variables = {
-      ALERTS_TABLE = var.alerts_table_name
+      ALERTS_TABLE = var.geo_fences_table_name
     }
   }
 }
@@ -94,7 +94,7 @@ resource "aws_lambda_function" "unsubscribe" {
   source_code_hash = data.archive_file.unsubscribe.output_base64sha256
   environment {
     variables = {
-      ALERTS_TABLE = var.alerts_table_name
+      ALERTS_TABLE = var.geo_fences_table_name
     }
   }
 }

--- a/terraform/api_gateway/variables.tf
+++ b/terraform/api_gateway/variables.tf
@@ -9,7 +9,7 @@ variable "cognito_user_pool_arn" {
   type        = string
 }
 
-variable "alerts_table_name" {
+variable "geo_fences_table_name" {
   description = "DynamoDB table for alert subscriptions"
   type        = string
 }

--- a/terraform/data-storage/.terraform.lock.hcl
+++ b/terraform/data-storage/.terraform.lock.hcl
@@ -1,9 +1,29 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.7.1"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
+    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
+    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
+    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
+    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
+    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
+    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
+    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
+    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
+    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
+    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
-  constraints = "~> 5.0"
+  constraints = ">= 5.0.0"
   hashes = [
     "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",

--- a/terraform/data-storage/main.tf
+++ b/terraform/data-storage/main.tf
@@ -129,3 +129,164 @@ resource "aws_dynamodb_table" "metadata" {
     region_name = var.secondary_region
   }
 }
+
+# DynamoDB table storing user geo fences with stream replication
+resource "aws_dynamodb_table" "geo_fences" {
+  name         = "geo_fences"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "user_id"
+  range_key    = "fence_id"
+
+  attribute {
+    name = "user_id"
+    type = "S"
+  }
+
+  attribute {
+    name = "fence_id"
+    type = "S"
+  }
+
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  replica {
+    region_name = var.secondary_region
+  }
+}
+
+# Package and deploy rule evaluation Lambda triggered by the table stream
+data "archive_file" "rule_eval" {
+  type        = "zip"
+  source_file = "${path.module}/../../lambda/rule_eval.py"
+  output_path = "${path.module}/dist/rule_eval.zip"
+}
+
+resource "aws_iam_role" "rule_eval" {
+  name = "${var.name}-rule-eval-role-${terraform.workspace}"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect    = "Allow",
+      Principal = { Service = "lambda.amazonaws.com" },
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "rule_eval_logs" {
+  role       = aws_iam_role.rule_eval.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy" "rule_eval" {
+  name = "${var.name}-rule-eval-policy-${terraform.workspace}"
+  role = aws_iam_role.rule_eval.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect   = "Allow",
+      Action   = ["events:PutEvents"],
+      Resource = "*"
+    }]
+  })
+}
+
+resource "aws_lambda_function" "rule_eval" {
+  function_name    = "${var.name}-rule-eval-${terraform.workspace}"
+  filename         = data.archive_file.rule_eval.output_path
+  source_code_hash = data.archive_file.rule_eval.output_base64sha256
+  handler          = "rule_eval.lambda_handler"
+  runtime          = "python3.12"
+  role             = aws_iam_role.rule_eval.arn
+}
+
+resource "aws_lambda_event_source_mapping" "geo_fences_stream" {
+  event_source_arn  = aws_dynamodb_table.geo_fences.stream_arn
+  function_name     = aws_lambda_function.rule_eval.arn
+  starting_position = "LATEST"
+}
+
+# SNS topic and push bridge Lambda for dispatching alerts
+resource "aws_kms_key" "fire_alert" {
+  description = "KMS key for fire-alert SNS topic"
+}
+
+resource "aws_sns_topic" "fire_alert" {
+  name              = "fire-alert"
+  kms_master_key_id = aws_kms_key.fire_alert.arn
+}
+
+data "archive_file" "push_bridge" {
+  type        = "zip"
+  source_file = "${path.module}/../../lambda/push_bridge.py"
+  output_path = "${path.module}/dist/push_bridge.zip"
+}
+
+resource "aws_iam_role" "push_bridge" {
+  name = "${var.name}-push-bridge-role-${terraform.workspace}"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect    = "Allow",
+      Principal = { Service = "lambda.amazonaws.com" },
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "push_bridge_logs" {
+  role       = aws_iam_role.push_bridge.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_lambda_function" "push_bridge" {
+  function_name    = "${var.name}-push-bridge-${terraform.workspace}"
+  filename         = data.archive_file.push_bridge.output_path
+  source_code_hash = data.archive_file.push_bridge.output_base64sha256
+  handler          = "push_bridge.lambda_handler"
+  runtime          = "python3.12"
+  role             = aws_iam_role.push_bridge.arn
+  environment {
+    variables = {
+      EXPO_TOKEN = var.expo_token
+    }
+  }
+}
+
+resource "aws_sns_topic_subscription" "push_bridge" {
+  topic_arn = aws_sns_topic.fire_alert.arn
+  protocol  = "lambda"
+  endpoint  = aws_lambda_function.push_bridge.arn
+}
+
+resource "aws_lambda_permission" "allow_sns_push_bridge" {
+  statement_id  = "AllowExecutionFromSNS"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.push_bridge.function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.fire_alert.arn
+}
+
+# Route events from rule evaluation to SNS
+resource "aws_cloudwatch_event_rule" "fire_dispatch" {
+  name = "${var.name}-fire-dispatch-${terraform.workspace}"
+  event_pattern = jsonencode({
+    source        = ["koalasafe.rule_eval"],
+    "detail-type" = ["FenceIntersection"]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "sns_target" {
+  rule      = aws_cloudwatch_event_rule.fire_dispatch.name
+  target_id = "sns"
+  arn       = aws_sns_topic.fire_alert.arn
+}
+
+resource "aws_lambda_permission" "allow_eventbridge_invoke_rule_eval" {
+  statement_id  = "AllowExecutionFromEventBridge"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.rule_eval.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.fire_dispatch.arn
+}

--- a/terraform/data-storage/outputs.tf
+++ b/terraform/data-storage/outputs.tf
@@ -6,6 +6,10 @@ output "dynamodb_table_name" {
   value = aws_dynamodb_table.metadata.name
 }
 
+output "geo_fences_table_name" {
+  value = aws_dynamodb_table.geo_fences.name
+}
+
 output "bucket_arn" {
   value = aws_s3_bucket.data.arn
 }

--- a/terraform/data-storage/variables.tf
+++ b/terraform/data-storage/variables.tf
@@ -12,3 +12,9 @@ variable "secondary_region" {
   type        = string
   description = "Secondary AWS region for replication"
 }
+
+variable "expo_token" {
+  type        = string
+  description = "Expo push token for push bridge Lambda"
+  default     = ""
+}

--- a/terraform/data-storage/versions.tf
+++ b/terraform/data-storage/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0"
     }
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2.0"
+    }
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -28,6 +28,7 @@ module "data_storage" {
   name             = var.name
   region           = var.region
   secondary_region = var.secondary_region
+  expo_token       = var.expo_token
 }
 
 module "ingest_firehose" {
@@ -57,4 +58,13 @@ module "edge_frontend" {
   domain_name        = var.domain_name
   origin_domain_name = var.origin_domain_name
   hosted_zone_id     = var.hosted_zone_id
+}
+
+module "api_gateway" {
+  source = "./api_gateway"
+
+  region                = var.region
+  cognito_user_pool_arn = var.cognito_user_pool_arn
+  geo_fences_table_name = module.data_storage.geo_fences_table_name
+  geojson_bucket        = module.data_storage.bucket_name
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -58,3 +58,14 @@ variable "hosted_zone_id" {
   type        = string
   description = "Route53 hosted zone ID"
 }
+
+variable "cognito_user_pool_arn" {
+  type        = string
+  description = "ARN of Cognito User Pool"
+}
+
+variable "expo_token" {
+  type        = string
+  description = "Expo push token for push bridge Lambda"
+  default     = ""
+}


### PR DESCRIPTION
## Summary
- add replicated `geo_fences` DynamoDB table with stream, rule evaluation Lambda, SNS topic, and push bridge Lambda for alerts
- expose geo-fence table name to the API and wire it into API Gateway IAM rules and Lambda environment
- parameterize expo push token and user pool ARN, and pass new table name from data storage to API Gateway module

## Testing
- `terraform init -backend=false` *(terraform/data-storage)*
- `terraform validate` *(terraform/data-storage)*
- `terraform init -backend=false` *(terraform/api_gateway)*
- `terraform validate` *(terraform/api_gateway)*

------
https://chatgpt.com/codex/tasks/task_e_688e6336e74483298f42f85b0d479b52