### PR TITLE
feat: parameterize fargate container image

### DIFF
--- a/terraform/compute-fargate/main.tf
+++ b/terraform/compute-fargate/main.tf
@@ -69,7 +69,7 @@ resource "aws_ecs_task_definition" "geojson" {
   container_definitions = jsonencode([
     {
       name      = "processor"
-      image     = "123456789012.dkr.ecr.${var.region}.amazonaws.com/geojson-processor:latest"
+      image     = var.container_image
       essential = true
       portMappings = [
         {

--- a/terraform/compute-fargate/variables.tf
+++ b/terraform/compute-fargate/variables.tf
@@ -22,3 +22,8 @@ variable "prometheus_endpoint" {
   type        = string
   description = "Remote write endpoint for Prometheus metrics"
 }
+
+variable "container_image" {
+  type        = string
+  description = "Container image for the geojson processor"
+}

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -1,2 +1,3 @@
 prometheus_endpoint = "https://prometheus.example.com"
+container_image     = "123456789012.dkr.ecr.us-east-1.amazonaws.com/geojson-processor:latest"
 


### PR DESCRIPTION
## Summary
- make Fargate task use `container_image` variable
- expose the container image variable and set via prod.tfvars

## Testing
- `terraform -chdir=terraform/compute-fargate init -backend=false`
- `terraform -chdir=terraform/compute-fargate validate`
- `pytest`

