### PR TITLE
refactor: use storage outputs for API gateway

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -50,16 +50,6 @@ module "compute_fargate" {
   security_group_ids  = [module.core_network.security_group_id]
   prometheus_endpoint = var.prometheus_endpoint
 }
-
-module "api_gateway" {
-  source = "./api_gateway"
-
-  region                = var.region
-  alerts_table_name     = var.alerts_table_name
-  geojson_bucket        = var.geojson_bucket
-  cognito_user_pool_arn = var.cognito_user_pool_arn
-}
-
 module "edge_frontend" {
   source = "./edge-frontend"
 

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -1,2 +1,4 @@
-prometheus_endpoint = "https://prometheus.example.com"
+prometheus_endpoint   = "https://prometheus.example.com"
+geo_fences_table_name = "geo-fences"
+geojson_bucket        = "geojson-data-bucket"
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -70,3 +70,18 @@ variable "expo_token" {
   default     = ""
 
 }
+
+variable "prometheus_endpoint" {
+  type        = string
+  description = "Prometheus remote write endpoint"
+}
+
+variable "geo_fences_table_name" {
+  type        = string
+  description = "DynamoDB table name for geo fences"
+}
+
+variable "geojson_bucket" {
+  type        = string
+  description = "S3 bucket for GeoJSON data"
+}


### PR DESCRIPTION
## Summary
- remove redundant API Gateway module using direct vars
- add variables for Prometheus and GeoJSON inputs
- include production variable defaults for new inputs

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false` *(fails: duplicate required providers configuration)*

