### PR TITLE
Adjust Route53 weighted routing

### DIFF
--- a/terraform/route53_failover.tf
+++ b/terraform/route53_failover.tf
@@ -37,7 +37,7 @@ resource "aws_route53_record" "sydney" {
   health_check_id = aws_route53_health_check.sydney.id
 
   weighted_routing_policy {
-    weight = 100
+    weight = 80
   }
 
   alias {
@@ -55,7 +55,7 @@ resource "aws_route53_record" "melbourne" {
   health_check_id = aws_route53_health_check.melbourne.id
 
   weighted_routing_policy {
-    weight = 0
+    weight = 20
   }
 
   alias {


### PR DESCRIPTION
## Summary
- set Route53 weights to 80 for Sydney and 20 for Melbourne

## Testing
- `terraform init`
- `terraform apply -auto-approve -var 'region=ap-southeast-2' -var 'hosted_zone_id=Z3EXAMPLE' -var 'domain_name=example.com' -var 'sydney_lb_dns=sydney.example.com' -var 'sydney_lb_zone_id=Z2SAMPLE' -var 'melbourne_lb_dns=melbourne.example.com' -var 'melbourne_lb_zone_id=Z2SAMPLE2'` *(fails: No valid credential sources found)*

