### PR TITLE
feat: add container image variable to Fargate module

### DIFF
--- a/terraform/compute-fargate/variables.tf
+++ b/terraform/compute-fargate/variables.tf
@@ -33,3 +33,8 @@ variable "output_bucket" {
   description = "S3 bucket for processed output"
 
 }
+
+variable "container_image" {
+  type        = string
+  description = "Container image for Fargate task"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -51,6 +51,7 @@ module "compute_fargate" {
   prometheus_endpoint = var.prometheus_endpoint
   firehose_bucket     = module.data_storage.bucket_name
   output_bucket       = module.data_storage.bucket_name
+  container_image     = var.container_image
 }
 module "edge_frontend" {
   source = "./edge-frontend"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -85,3 +85,8 @@ variable "geojson_bucket" {
   type        = string
   description = "S3 bucket for GeoJSON data"
 }
+
+variable "container_image" {
+  type        = string
+  description = "Container image for Fargate task"
+}


### PR DESCRIPTION
## Summary
- add container_image variable to compute-fargate module
- expose container_image variable in root module
- wire container_image through main compute_fargate module call

## Testing
- `mise exec terraform@1.5.7 -- terraform fmt -recursive`
- `terraform init -backend=false` *(fails: Duplicate required providers configuration)*
- `terraform -chdir=terraform/compute-fargate init -backend=false`
- `terraform -chdir=terraform/compute-fargate validate`
- `pytest`

