### PR TITLE
ci: run tfsec after plan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
         run: terraform -chdir=terraform workspace select $TF_WORKSPACE || terraform -chdir=terraform workspace new $TF_WORKSPACE
       - name: Terraform Plan
         run: terraform -chdir=terraform plan -out=tfplan
+      - name: tfsec
+        uses: aquasecurity/tfsec-action@v1
+        with:
+          working_directory: terraform
+          additional_args: --minimum-severity HIGH
       - name: Show Plan JSON
         run: terraform -chdir=terraform show -json tfplan > tfplan.json
       - name: Conftest

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -55,6 +55,11 @@ jobs:
         run: terraform -chdir=terraform workspace select prod || terraform -chdir=terraform workspace new prod
       - name: Terraform Plan
         run: terraform -chdir=terraform plan
+      - name: tfsec
+        uses: aquasecurity/tfsec-action@v1
+        with:
+          working_directory: terraform
+          additional_args: --minimum-severity HIGH
       - name: Terraform Apply
         run: terraform -chdir=terraform apply -auto-approve
 


### PR DESCRIPTION
## Summary
- run tfsec security scanner after terraform plan
- fail workflows when tfsec reports high or critical severity issues

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e6c792e30832987a20c3622ed4b6d