### PR TITLE
feat: manage secrets via AWS Secrets Manager

### DIFF
--- a/src/ingest_lambda/handlers.py
+++ b/src/ingest_lambda/handlers.py
@@ -10,6 +10,12 @@ FIREHOSE_STREAM_NAME = os.environ.get("FIREHOSE_STREAM_NAME", "bushfire_raw")
 firehose = boto3.client("firehose", region_name=os.environ.get("AWS_REGION", "us-east-1"))
 
 NSW_RFS_URL = "https://www.rfs.nsw.gov.au/feeds/majorIncidents.json"
+NASA_API_KEY = os.environ.get("NASA_API_KEY")
+NASA_API_KEY_SECRET_ARN = os.environ.get("NASA_API_KEY_SECRET_ARN")
+if NASA_API_KEY_SECRET_ARN and not NASA_API_KEY:
+    sm = boto3.client("secretsmanager", region_name=os.environ.get("AWS_REGION", "us-east-1"))
+    resp = sm.get_secret_value(SecretId=NASA_API_KEY_SECRET_ARN)
+    NASA_API_KEY = resp.get("SecretString")
 NASA_FIRMS_URL = (
     "https://firms.modaps.eosdis.nasa.gov/active_fire/c6/geojson/MODIS_C6_Australia_NewZealand_24h.geojson"
 )

--- a/terraform/compute-fargate/variables.tf
+++ b/terraform/compute-fargate/variables.tf
@@ -33,3 +33,8 @@ variable "output_bucket" {
   description = "S3 bucket for processed output"
 
 }
+
+variable "mapbox_token_secret_arn" {
+  type        = string
+  description = "ARN of the Mapbox token secret"
+}

--- a/terraform/data-storage/main.tf
+++ b/terraform/data-storage/main.tf
@@ -249,9 +249,26 @@ resource "aws_lambda_function" "push_bridge" {
   role             = aws_iam_role.push_bridge.arn
   environment {
     variables = {
-      EXPO_TOKEN = var.expo_token
+      EXPO_TOKEN_SECRET_ARN = var.expo_token_secret_arn
     }
   }
+}
+
+resource "aws_iam_policy" "push_bridge_secret" {
+  name = "${var.name}-push-bridge-secret-${terraform.workspace}"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Action   = ["secretsmanager:GetSecretValue"],
+      Effect   = "Allow",
+      Resource = var.expo_token_secret_arn
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "push_bridge_secret_attach" {
+  role       = aws_iam_role.push_bridge.name
+  policy_arn = aws_iam_policy.push_bridge_secret.arn
 }
 
 resource "aws_sns_topic_subscription" "push_bridge" {

--- a/terraform/data-storage/variables.tf
+++ b/terraform/data-storage/variables.tf
@@ -13,8 +13,7 @@ variable "secondary_region" {
   description = "Secondary AWS region for replication"
 }
 
-variable "expo_token" {
+variable "expo_token_secret_arn" {
   type        = string
-  description = "Expo push token for push bridge Lambda"
-  default     = ""
+  description = "ARN of the Expo push token secret"
 }

--- a/terraform/ingest-firehose/main.tf
+++ b/terraform/ingest-firehose/main.tf
@@ -46,9 +46,27 @@ resource "aws_lambda_function" "processor" {
 
   environment {
     variables = {
-      FIREHOSE_STREAM_NAME = aws_kinesis_firehose_delivery_stream.stream.name
+      FIREHOSE_STREAM_NAME    = aws_kinesis_firehose_delivery_stream.stream.name,
+      NASA_API_KEY_SECRET_ARN = var.nasa_api_key_secret_arn
     }
   }
+}
+
+resource "aws_iam_policy" "lambda_secret" {
+  name = "${var.name}-lambda-secret"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Action   = ["secretsmanager:GetSecretValue"],
+      Effect   = "Allow",
+      Resource = var.nasa_api_key_secret_arn
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_secret_attach" {
+  role       = aws_iam_role.lambda_exec.name
+  policy_arn = aws_iam_policy.lambda_secret.arn
 }
 
 # Schedule to run every 30 seconds

--- a/terraform/ingest-firehose/variables.tf
+++ b/terraform/ingest-firehose/variables.tf
@@ -22,3 +22,8 @@ variable "delivery_bucket_arn" {
   type        = string
   description = "Destination S3 bucket ARN for Firehose"
 }
+
+variable "nasa_api_key_secret_arn" {
+  type        = string
+  description = "ARN of the NASA API key secret"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -25,32 +25,34 @@ module "core_network" {
 module "data_storage" {
   source = "./data-storage"
 
-  name             = var.name
-  region           = var.region
-  secondary_region = var.secondary_region
-  expo_token       = var.expo_token
+  name                  = var.name
+  region                = var.region
+  secondary_region      = var.secondary_region
+  expo_token_secret_arn = aws_secretsmanager_secret.expo_token.arn
 }
 
 module "ingest_firehose" {
   source = "./ingest-firehose"
 
-  name                = var.name
-  region              = var.region
-  lambda_s3_bucket    = var.lambda_s3_bucket
-  lambda_s3_key       = var.lambda_s3_key
-  delivery_bucket_arn = module.data_storage.bucket_arn
+  name                    = var.name
+  region                  = var.region
+  lambda_s3_bucket        = var.lambda_s3_bucket
+  lambda_s3_key           = var.lambda_s3_key
+  delivery_bucket_arn     = module.data_storage.bucket_arn
+  nasa_api_key_secret_arn = aws_secretsmanager_secret.nasa_api_key.arn
 }
 
 module "compute_fargate" {
   source = "./compute-fargate"
 
-  name                = var.name
-  region              = var.region
-  subnet_ids          = module.core_network.private_subnet_ids
-  security_group_ids  = [module.core_network.security_group_id]
-  prometheus_endpoint = var.prometheus_endpoint
-  firehose_bucket     = module.data_storage.bucket_name
-  output_bucket       = module.data_storage.bucket_name
+  name                    = var.name
+  region                  = var.region
+  subnet_ids              = module.core_network.private_subnet_ids
+  security_group_ids      = [module.core_network.security_group_id]
+  prometheus_endpoint     = var.prometheus_endpoint
+  firehose_bucket         = module.data_storage.bucket_name
+  output_bucket           = module.data_storage.bucket_name
+  mapbox_token_secret_arn = aws_secretsmanager_secret.mapbox_token.arn
 }
 module "edge_frontend" {
   source = "./edge-frontend"

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -1,0 +1,35 @@
+resource "aws_secretsmanager_secret" "nasa_api_key" {
+  name = "${var.name}-nasa-api-key"
+}
+
+resource "aws_secretsmanager_secret_rotation" "nasa_api_key" {
+  secret_id           = aws_secretsmanager_secret.nasa_api_key.id
+  rotation_lambda_arn = var.secret_rotation_lambda_arn
+  rotation_rules {
+    automatically_after_days = 30
+  }
+}
+
+resource "aws_secretsmanager_secret" "mapbox_token" {
+  name = "${var.name}-mapbox-token"
+}
+
+resource "aws_secretsmanager_secret_rotation" "mapbox_token" {
+  secret_id           = aws_secretsmanager_secret.mapbox_token.id
+  rotation_lambda_arn = var.secret_rotation_lambda_arn
+  rotation_rules {
+    automatically_after_days = 30
+  }
+}
+
+resource "aws_secretsmanager_secret" "expo_token" {
+  name = "${var.name}-expo-token"
+}
+
+resource "aws_secretsmanager_secret_rotation" "expo_token" {
+  secret_id           = aws_secretsmanager_secret.expo_token.id
+  rotation_lambda_arn = var.secret_rotation_lambda_arn
+  rotation_rules {
+    automatically_after_days = 30
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -43,6 +43,11 @@ variable "lambda_s3_key" {
   description = "S3 key for Lambda code"
 }
 
+variable "secret_rotation_lambda_arn" {
+  type        = string
+  description = "ARN of the Lambda function that rotates secrets"
+}
+
 
 variable "domain_name" {
   type        = string
@@ -64,12 +69,6 @@ variable "cognito_user_pool_arn" {
   description = "ARN of Cognito User Pool"
 }
 
-variable "expo_token" {
-  type        = string
-  description = "Expo push token for push bridge Lambda"
-  default     = ""
-
-}
 
 variable "prometheus_endpoint" {
   type        = string

--- a/tests/test_push_bridge.py
+++ b/tests/test_push_bridge.py
@@ -16,20 +16,42 @@ def _mock_urlopen():
 
 
 def test_push_bridge_with_token():
-    push_bridge.EXPO_TOKEN = "token123"
-    with patch("urllib.request.urlopen", return_value=_mock_urlopen()) as mock_open:
-        event = {"detail": {"device_token": "d1", "fence_id": "f1"}}
-        result = push_bridge.lambda_handler(event, None)
-    request = mock_open.call_args[0][0]
-    assert request.headers["Authorization"] == "Bearer token123"
-    assert result == {"status": "sent"}
+    os.environ["EXPO_TOKEN"] = "token123"
+    try:
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen()) as mock_open:
+            event = {"detail": {"device_token": "d1", "fence_id": "f1"}}
+            result = push_bridge.lambda_handler(event, None)
+        request = mock_open.call_args[0][0]
+        assert request.headers["Authorization"] == "Bearer token123"
+        assert result == {"status": "sent"}
+    finally:
+        del os.environ["EXPO_TOKEN"]
 
 
 def test_push_bridge_without_token():
-    push_bridge.EXPO_TOKEN = None
+    if "EXPO_TOKEN" in os.environ:
+        del os.environ["EXPO_TOKEN"]
+    if "EXPO_TOKEN_SECRET_ARN" in os.environ:
+        del os.environ["EXPO_TOKEN_SECRET_ARN"]
     with patch("urllib.request.urlopen", return_value=_mock_urlopen()) as mock_open:
         event = {"detail": {"device_token": "d1", "fence_id": "f1"}}
         result = push_bridge.lambda_handler(event, None)
     request = mock_open.call_args[0][0]
     assert "Authorization" not in request.headers
     assert result == {"status": "sent"}
+
+
+def test_push_bridge_with_secret():
+    os.environ["EXPO_TOKEN_SECRET_ARN"] = "arn:expo"
+    mock_client = MagicMock()
+    mock_client.get_secret_value.return_value = {"SecretString": "secretXYZ"}
+    try:
+        with patch("boto3.client", return_value=mock_client):
+            with patch("urllib.request.urlopen", return_value=_mock_urlopen()) as mock_open:
+                event = {"detail": {"device_token": "d1", "fence_id": "f1"}}
+                result = push_bridge.lambda_handler(event, None)
+        request = mock_open.call_args[0][0]
+        assert request.headers["Authorization"] == "Bearer secretXYZ"
+        assert result == {"status": "sent"}
+    finally:
+        del os.environ["EXPO_TOKEN_SECRET_ARN"]


### PR DESCRIPTION
## Summary
- store NASA API key, Mapbox token, and Expo token in Secrets Manager with 30-day rotation
- propagate secret ARNs to Lambda and ECS tasks and allow retrieval
- load secrets at runtime for push notifications and ingest Lambda

## Testing
- `terraform fmt -recursive`
- `terraform validate` *(fails: Duplicate required providers configuration)*
- `terraform -chdir=compute-fargate validate` *(fails: Reference to undeclared input variable)
- `terraform -chdir=data-storage validate`
- `terraform -chdir=ingest-firehose validate`
- `pytest`
