### PR TITLE
Expose container image variable for Fargate module

### DIFF
--- a/terraform/compute-fargate/variables.tf
+++ b/terraform/compute-fargate/variables.tf
@@ -18,6 +18,11 @@ variable "security_group_ids" {
   description = "Security groups for the load balancer"
 }
 
+variable "container_image" {
+  type        = string
+  description = "Container image for Fargate task"
+}
+
 variable "prometheus_endpoint" {
   type        = string
   description = "Remote write endpoint for Prometheus metrics"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -49,6 +49,7 @@ module "compute_fargate" {
   region                  = var.region
   subnet_ids              = module.core_network.private_subnet_ids
   security_group_ids      = [module.core_network.security_group_id]
+  container_image         = var.container_image
   prometheus_endpoint     = var.prometheus_endpoint
   firehose_bucket         = module.data_storage.bucket_name
   output_bucket           = module.data_storage.bucket_name


### PR DESCRIPTION
## Summary
- add container_image input to compute-fargate module
- wire container_image from root module into compute-fargate

## Testing
- `terraform -chdir=terraform fmt -recursive`
- `terraform -chdir=terraform init -backend=false` *(fails: duplicate provider configuration)*
- `terraform -chdir=terraform validate` *(fails: duplicate provider configuration)*


