### PR TITLE
Refactor alert subscription key schema

### DIFF
--- a/src/api/subscribe.py
+++ b/src/api/subscribe.py
@@ -1,6 +1,5 @@
 import json
 import os
-import uuid
 import boto3
 
 dynamodb = boto3.resource('dynamodb')
@@ -11,14 +10,14 @@ def subscribeFn(event, context):
     table = dynamodb.Table(os.environ['ALERTS_TABLE'])
     user_id = event['requestContext']['authorizer']['claims']['sub']
     body = json.loads(event.get('body') or '{}')
-    alert_id = str(uuid.uuid4())
+    fence_id = body['fence_id']
     item = {
-        'id': alert_id,
         'user_id': user_id,
+        'fence_id': fence_id,
         'params': body
     }
     table.put_item(Item=item)
     return {
         'statusCode': 201,
-        'body': json.dumps({'id': alert_id})
+        'body': json.dumps({'fence_id': fence_id})
     }

--- a/src/api/unsubscribe.py
+++ b/src/api/unsubscribe.py
@@ -11,12 +11,11 @@ def unsubscribeFn(event, context):
     """Remove alert subscription belonging to the authenticated user."""
     table = dynamodb.Table(os.environ['ALERTS_TABLE'])
     user_id = event['requestContext']['authorizer']['claims']['sub']
-    alert_id = event['pathParameters']['id']
+    fence_id = event['pathParameters']['fence_id']
     try:
         table.delete_item(
-            Key={'id': alert_id},
-            ConditionExpression='user_id = :u',
-            ExpressionAttributeValues={':u': user_id}
+            Key={'user_id': user_id, 'fence_id': fence_id},
+            ConditionExpression='attribute_exists(fence_id)'
         )
     except ClientError as exc:
         if exc.response['Error']['Code'] == 'ConditionalCheckFailedException':

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -4,6 +4,8 @@ import json
 from unittest.mock import MagicMock, patch
 from botocore.exceptions import ClientError
 
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from api import subscribe, unsubscribe
@@ -13,32 +15,34 @@ def test_subscribe_stores_alert(monkeypatch=None):
     os.environ["ALERTS_TABLE"] = "alerts"
     event = {
         "requestContext": {"authorizer": {"claims": {"sub": "user1"}}},
-        "body": json.dumps({"type": "fire"}),
+        "body": json.dumps({"type": "fire", "fence_id": "f1"}),
     }
     mock_table = MagicMock()
     with patch.object(subscribe.dynamodb, "Table", return_value=mock_table):
-        with patch("uuid.uuid4", return_value="uuid1"):
-            response = subscribe.subscribeFn(event, None)
+        response = subscribe.subscribeFn(event, None)
     mock_table.put_item.assert_called_once_with(
-        Item={"id": "uuid1", "user_id": "user1", "params": {"type": "fire"}}
+        Item={
+            "user_id": "user1",
+            "fence_id": "f1",
+            "params": {"type": "fire", "fence_id": "f1"},
+        }
     )
     assert response["statusCode"] == 201
-    assert json.loads(response["body"]) == {"id": "uuid1"}
+    assert json.loads(response["body"]) == {"fence_id": "f1"}
 
 
 def test_unsubscribe_deletes_alert(monkeypatch=None):
     os.environ["ALERTS_TABLE"] = "alerts"
     event = {
         "requestContext": {"authorizer": {"claims": {"sub": "user1"}}},
-        "pathParameters": {"id": "alert1"},
+        "pathParameters": {"fence_id": "f1"},
     }
     mock_table = MagicMock()
     with patch.object(unsubscribe.dynamodb, "Table", return_value=mock_table):
         response = unsubscribe.unsubscribeFn(event, None)
     mock_table.delete_item.assert_called_once_with(
-        Key={"id": "alert1"},
-        ConditionExpression="user_id = :u",
-        ExpressionAttributeValues={":u": "user1"},
+        Key={"user_id": "user1", "fence_id": "f1"},
+        ConditionExpression="attribute_exists(fence_id)",
     )
     assert response["statusCode"] == 204
 
@@ -47,7 +51,7 @@ def test_unsubscribe_not_found(monkeypatch=None):
     os.environ["ALERTS_TABLE"] = "alerts"
     event = {
         "requestContext": {"authorizer": {"claims": {"sub": "user1"}}},
-        "pathParameters": {"id": "alert1"},
+        "pathParameters": {"fence_id": "f1"},
     }
     mock_table = MagicMock()
     error_response = {"Error": {"Code": "ConditionalCheckFailedException"}}


### PR DESCRIPTION
## Summary
- store subscriptions keyed by user_id and fence_id
- delete subscriptions using composite key
- update tests for new subscription schema

## Testing
- `pytest -q`

