### PR TITLE
Remove unused Terraform variables for geo fences and geojson

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -75,16 +75,6 @@ variable "prometheus_endpoint" {
   description = "Prometheus remote write endpoint"
 }
 
-variable "geo_fences_table_name" {
-  type        = string
-  description = "DynamoDB table name for geo fences"
-}
-
-variable "geojson_bucket" {
-  type        = string
-  description = "S3 bucket for GeoJSON data"
-}
-
 variable "container_image" {
   type        = string
   description = "Container image for Fargate task"


### PR DESCRIPTION
## Summary
- remove unused `geo_fences_table_name` and `geojson_bucket` variables
- reference data-storage outputs directly when invoking API Gateway module

## Testing
- `terraform -chdir=terraform fmt`
- `terraform -chdir=terraform init -backend=false` *(fails: Duplicate required providers configuration and variable declarations)*
