### PR TITLE
Add ACM cert DNS validation for edge frontend

### DIFF
--- a/terraform/edge-frontend/main.tf
+++ b/terraform/edge-frontend/main.tf
@@ -7,6 +7,28 @@ resource "aws_acm_certificate" "cert" {
   validation_method = "DNS"
 }
 
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  type            = each.value.type
+  ttl             = 60
+  zone_id         = var.hosted_zone_id
+}
+
+resource "aws_acm_certificate_validation" "cert_validation" {
+  certificate_arn         = aws_acm_certificate.cert.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+}
+
 resource "aws_cloudfront_distribution" "cdn" {
   enabled    = true
   web_acl_id = aws_wafv2_web_acl.waf.arn
@@ -34,7 +56,7 @@ resource "aws_cloudfront_distribution" "cdn" {
   }
 
   viewer_certificate {
-    acm_certificate_arn      = aws_acm_certificate.cert.arn
+    acm_certificate_arn      = aws_acm_certificate_validation.cert_validation.certificate_arn
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1.2_2021"
   }


### PR DESCRIPTION
## Summary
- add Route53 DNS records for ACM certificate validation
- validate ACM certificate before using it in CloudFront

## Testing
- `terraform -chdir=terraform/edge-frontend fmt`
- `terraform -chdir=terraform/edge-frontend init -backend=false`
- `terraform -chdir=terraform/edge-frontend validate`

