### PR TITLE
feat: add VPC gateway endpoints for S3 and DynamoDB

### DIFF
--- a/terraform/core-network/main.tf
+++ b/terraform/core-network/main.tf
@@ -89,6 +89,28 @@ resource "aws_route_table_association" "private" {
   route_table_id = aws_route_table.private.id
 }
 
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.${var.region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = [aws_route_table.private.id]
+
+  tags = {
+    Name = "${var.name}-s3-endpoint"
+  }
+}
+
+resource "aws_vpc_endpoint" "dynamodb" {
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.${var.region}.dynamodb"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = [aws_route_table.private.id]
+
+  tags = {
+    Name = "${var.name}-dynamodb-endpoint"
+  }
+}
+
 resource "aws_security_group" "default" {
   name        = "${var.name}-sg"
   description = "Default security group for core network"

--- a/terraform/core-network/outputs.tf
+++ b/terraform/core-network/outputs.tf
@@ -29,3 +29,11 @@ output "private_route_table_id" {
 output "security_group_id" {
   value = aws_security_group.default.id
 }
+
+output "s3_vpc_endpoint_id" {
+  value = aws_vpc_endpoint.s3.id
+}
+
+output "dynamodb_vpc_endpoint_id" {
+  value = aws_vpc_endpoint.dynamodb.id
+}


### PR DESCRIPTION
## Summary
- add VPC gateway endpoints for S3 and DynamoDB
- output endpoint IDs for reuse in other modules

## Testing
- `terraform -chdir=terraform/core-network fmt -check`
- `terraform -chdir=terraform/core-network init -backend=false`
- `terraform -chdir=terraform/core-network validate`

